### PR TITLE
change workflow target branch to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI/CD
 on:
   push:
     branches:
-    - master
+    - main
     paths:
     - "doc/**.md"
     - "book.toml"
@@ -24,5 +24,5 @@ jobs:
       env:
         ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
         EXTERNAL_REPOSITORY: KazutoMurase/KazutoMurase.github.io
-        PUBLISH_BRANCH: master
+        PUBLISH_BRANCH: main
         PUBLISH_DIR: ./book


### PR DESCRIPTION
githubではデフォルトブランチがmaster -> mainになっていて(人権運動が背景にあります)、一応その最新事情に合わせておきます (既にレポジトリ設定でmainにしたので、CIがmainに対して適切に走るように変更しておきます)