### PR TITLE
fix null check of winners when winner doesn't exist

### DIFF
--- a/components/get_result.js
+++ b/components/get_result.js
@@ -962,10 +962,18 @@ function GetResult({
                   <td>第4位</td>
                 </tr>
                 <tr style={{ height: "80px" }}>
-                  <td>{winner1 !== null ? ShowWinner(winner1) : ""}</td>
-                  <td>{winner2 !== null ? ShowWinner(winner2) : ""}</td>
-                  <td>{winner3 !== null ? ShowWinner(winner3) : ""}</td>
-                  <td>{winner4 !== null ? ShowWinner(winner4) : ""}</td>
+                  <td>
+                    {winner1 ? (winner1.name ? ShowWinner(winner1) : "") : ""}
+                  </td>
+                  <td>
+                    {winner2 ? (winner2.name ? ShowWinner(winner2) : "") : ""}
+                  </td>
+                  <td>
+                    {winner3 ? (winner3.name ? ShowWinner(winner3) : "") : ""}
+                  </td>
+                  <td>
+                    {winner4 ? (winner4.name ? ShowWinner(winner4) : "") : ""}
+                  </td>
                 </tr>
               </tbody>
             </table>


### PR DESCRIPTION
テストのためにtestデータベースで適当に結果を記録していたところ、「1~4位が決まる試合の前に両者棄権してしまった場合」にnullチェックがうまく効かずにエラーとなってしまうことがありました。
![error_display](https://github.com/KazutoMurase/taido-competition-record/assets/167593243/12a6276b-0e6a-4ac4-93da-91933803248d)

もともとwinner1~4自体のnullチェックはありましたが、例えばwinner4がいない場合、以下のコードで各キーに対応する値がundefinedなobjectが付与されてしまうのでチェックが効きません。本来はwinner4がいないことを早めに検知しておくべきかもしれないですが、それだと条件分岐が多くなるため表示部でのobject中身チェックで代替しました。
https://github.com/KazutoMurase/taido-competition-record/blob/ecc90295c6a0d300a884158368ba417d139c9207/components/get_result.js#L867-L871

これにより、以下のような状況でもエラーを吐かずに表示できます。
![erroneous_tournament_result](https://github.com/KazutoMurase/taido-competition-record/assets/167593243/5240f1f1-0b90-4009-a591-9af2ab32b98f)
