### PR TITLE
set fixed width for progress check page

### DIFF
--- a/pages/progress_check.tsx
+++ b/pages/progress_check.tsx
@@ -5,7 +5,7 @@ import ProgressOnBlock from "../components/progress_on_block";
 
 const ProgressCheck: React.FC = () => {
   return (
-    <>
+    <div style={{ width: "1900px" }}>
       <Grid container>
         <Grid item xs={3}>
           <ProgressOnBlock
@@ -36,7 +36,7 @@ const ProgressCheck: React.FC = () => {
           />
         </Grid>
       </Grid>
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
@shintarokkkk 崩れない固定widthを設定するのが早いかなと思いましたがどうでしょう？
一応携帯とかからも見たりして、崩れなさそう。

スクロールしないといけないけども、やっぱり時程表は横並びで見たいなと思っているのですがどうだろうか。