### PR TITLE
view progress check in main and update periodically

### DIFF
--- a/components/get_result.js
+++ b/components/get_result.js
@@ -837,7 +837,7 @@ function ShowWinner(item) {
 
 function GetResult({
   editable = false,
-  updateInterval = 0,
+  updateInterval = 10000,
   returnUrl = null,
   event_name = null,
   block_number = null,

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,13 +1,12 @@
-import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import React from "react";
 import Container from "@mui/material/Container";
 import Button from "@mui/material/Button";
 import Grid from "@mui/material/Grid";
-import checkStyles from "../styles/checks.module.css";
 import GetEvents from "../components/get_events";
 
 export default function Home() {
+  const router = useRouter();
   return (
     <div>
       <br />
@@ -19,10 +18,41 @@ export default function Home() {
           style={{ height: "100px" }}
         >
           <h1>
-            <u>躰道 第56回全日本大会 個人競技速報</u>
+            <u>躰道 第56回全日本大会</u>
           </h1>
         </Grid>
-        <GetEvents />
+        <Grid
+          container
+          justifyContent="center"
+          alignItems="center"
+          style={{ height: "60px" }}
+        >
+          <Button
+            variant="contained"
+            type="submit"
+            onClick={(e) => {
+              router.push("/progress_check");
+            }}
+          >
+            時程表
+          </Button>
+        </Grid>
+        <Grid
+          container
+          justifyContent="center"
+          alignItems="center"
+          style={{ height: "60px" }}
+        >
+          <Button
+            variant="contained"
+            type="submit"
+            onClick={(e) => {
+              router.push("/results");
+            }}
+          >
+            競技結果一覧
+          </Button>
+        </Grid>
       </Container>
     </div>
   );

--- a/pages/progress_check.tsx
+++ b/pages/progress_check.tsx
@@ -10,28 +10,28 @@ const ProgressCheck: React.FC = () => {
         <Grid item xs={3}>
           <ProgressOnBlock
             block_number="a"
-            update_interval={1000}
+            update_interval={10000}
             return_url="/"
           />
         </Grid>
         <Grid item xs={3}>
           <ProgressOnBlock
             block_number="b"
-            update_interval={1000}
+            update_interval={10000}
             return_url="/"
           />
         </Grid>
         <Grid item xs={3}>
           <ProgressOnBlock
             block_number="c"
-            update_interval={1000}
+            update_interval={10000}
             return_url="/"
           />
         </Grid>
         <Grid item xs={3}>
           <ProgressOnBlock
             block_number="d"
-            update_interval={1000}
+            update_interval={10000}
             return_url="/"
           />
         </Grid>


### PR DESCRIPTION
1. 時程表をupdate_intervalが0より大きい時はそのインターバルでcurrentScheculeをfetchしにいくようにします。
2. 観客用メインページから時程表と結果一覧のページに飛べるようにし、またデフォルトでどちらも10秒間隔で自動更新されるようにします (このくらいの負荷でどのくらいの課金になるか知りたいです。創玄杯もできればこれでいってみたい。昨年の本番は60秒にしていましたが)
3. 時程表の競技名からもトーナメント(結果)にいけるようリンク貼りました
