### PR TITLE
fix Link import

### DIFF
--- a/components/progress_on_block.tsx
+++ b/components/progress_on_block.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { Link } from "next/link";
+import Link from "next/link";
 import Button from "@mui/material/Button";
 import checkStyles from "../styles/checks.module.css";
 import Container from "@mui/material/Container";


### PR DESCRIPTION
"npm build"でコケた...やっぱこれちゃんとCIでみたい

Step #0 - "Build": Type error: Module '"next/link"' has no exported member 'Link'. Did you mean to use 'import Link from "next/link"' instead?
