### PR TITLE
show color on check dantai on block

### DIFF
--- a/components/check_dantai_on_block.js
+++ b/components/check_dantai_on_block.js
@@ -224,6 +224,7 @@ function CheckDantai({
           <table border="1">
             <tbody>
               <tr className={checkStyles.column}>
+                {GetEventName(event_id) === "dantai" ? <></> : <th>色</th>}
                 <th>団体名</th>
                 <th>点呼完了</th>
                 <th>棄権</th>
@@ -233,6 +234,16 @@ function CheckDantai({
               </tr>
               {data.map((item, index) => (
                 <tr key={item["id"]} className={checkStyles.column}>
+                  {GetEventName(event_id) === "dantai" ? (
+                    <></>
+                  ) : (
+                    <td>
+                      <SquareTwoToneIcon
+                        sx={{ fontSize: 60 }}
+                        htmlColor={item["color"] === "red" ? "red" : "gray"}
+                      />
+                    </td>
+                  )}
                   <td>{item["name"].replace("'", "").replace("'", "")}</td>
                   <td className={checkStyles.elem}>
                     <input


### PR DESCRIPTION
団体実戦呼び出し時に赤/白どちらか分かるように表示をつけます(個人だとサポートされているのをこちらでもサポート忘れていました)

![Screenshot from 2024-06-05 22-52-04](https://github.com/KazutoMurase/taido-competition-record/assets/3016693/260abb9c-8925-4c32-9c0d-56ef967b24c7)


Fixes https://github.com/KazutoMurase/taido-competition-record/issues/64