### PR TITLE
disable invalid link on progress check page

### DIFF
--- a/components/progress_on_block.tsx
+++ b/components/progress_on_block.tsx
@@ -110,9 +110,16 @@ const ProgressOnBlock: React.FC<{
         >
           <td>{schedule.time_schedule?.replace(/['"]+/g, "")}</td>
           <td>
-            <a href={"results/" + GetEventName(schedule.event_id)}>
-              {test_event_id_vs_event_name.get(schedule.event_id)}
-            </a>
+            {GetEventName(schedule.event_id) === "dantai" ? (
+              <>{test_event_id_vs_event_name.get(schedule.event_id)}</>
+            ) : (
+              <a
+                className="color-disabled"
+                href={"results/" + GetEventName(schedule.event_id)}
+              >
+                {test_event_id_vs_event_name.get(schedule.event_id)}
+              </a>
+            )}
           </td>
           <td>{schedule.games_text}</td>
           <td>

--- a/styles/global.css
+++ b/styles/global.css
@@ -26,6 +26,10 @@ a:hover {
   text-decoration: underline;
 }
 
+.color-disabled {
+  color: #000000;
+}
+
 * {
   box-sizing: border-box;
 }


### PR DESCRIPTION
Fixes https://github.com/KazutoMurase/taido-competition-record/issues/70

"全日程終了"やまだサポートしていない団体競技に対して不正なリンクが貼られてしまうのを防止します