### PR TITLE
support notification request for all

### DIFF
--- a/components/check_dantai_on_block.js
+++ b/components/check_dantai_on_block.js
@@ -221,6 +221,29 @@ function CheckDantai({
                 : ""}
             </h3>
           </Grid>
+          <Grid
+            container
+            justifyContent="center"
+            alignItems="center"
+            style={{ height: "80px" }}
+          >
+            <Button
+              variant="contained"
+              type="submit"
+              onClick={(e) =>
+                onSubmit(
+                  block_number,
+                  null,
+                  null,
+                  event_id,
+                  is_test,
+                  forceFetchData,
+                )
+              }
+            >
+              全体呼び出し
+            </Button>
+          </Grid>
           <table border="1">
             <tbody>
               <tr className={checkStyles.column}>

--- a/components/check_players_on_block.js
+++ b/components/check_players_on_block.js
@@ -191,6 +191,22 @@ function CheckPlayers({
               <u>コート{block_number.toUpperCase()}</u>
             </h2>
           </Grid>
+          <Grid
+            container
+            justifyContent="center"
+            alignItems="center"
+            style={{ height: "80px" }}
+          >
+            <Button
+              variant="contained"
+              type="submit"
+              onClick={(e) =>
+                onSubmit(null, block_number, event_id, is_test, forceFetchData)
+              }
+            >
+              全体呼び出し
+            </Button>
+          </Grid>
           <table border="1">
             <tbody>
               <tr className={checkStyles.column}>

--- a/components/notification_request.js
+++ b/components/notification_request.js
@@ -30,6 +30,7 @@ function onClear(item, is_test, function_after_post) {
       group_id: item.group_id,
       is_test: is_test,
       event_id: item.event_id,
+      court_id: item.court_id,
     };
   }
   axios
@@ -46,7 +47,11 @@ function ShowName(item) {
   if ("name" in item) {
     return item["name"] + "(" + item["name_kana"] + ")";
   }
-  return item["group_name"].replace("'", "").replace("'", "") + "チーム";
+  if ("group_name" in item) {
+    return item["group_name"].replace("'", "").replace("'", "") + "チーム";
+  } else {
+    return "全体";
+  }
 }
 
 function NotificationRequest({ update_interval, return_url, is_test = false }) {

--- a/pages/api/clear_notification_request.js
+++ b/pages/api/clear_notification_request.js
@@ -8,18 +8,26 @@ const ClearNotificationRequest = async (req, res) => {
       req.body.is_test === true
         ? "test_notification_request"
         : "notification_request";
-    if (req.body.player_id !== undefined) {
+    if (req.body.player_id) {
       const query =
         "DELETE FROM " + notification_request_name + " WHERE player_id = $1";
       const values = [req.body.player_id];
       const result = await client.query(query, values);
       console.log(result);
-    } else if (req.body.group_id !== undefined) {
+    } else if (req.body.group_id) {
       const query =
         "DELETE FROM " +
         notification_request_name +
         " WHERE group_id = $1 and event_id = $2";
       const values = [req.body.group_id, req.body.event_id];
+      const result = await client.query(query, values);
+      console.log(result);
+    } else if (req.body.event_id) {
+      const query =
+        "DELETE FROM " +
+        notification_request_name +
+        " WHERE event_id = $1 and court_id = $2 and group_id is null and player_id is null";
+      const values = [req.body.event_id, req.body.court_id];
       const result = await client.query(query, values);
       console.log(result);
     } else {

--- a/pages/api/notification_request.js
+++ b/pages/api/notification_request.js
@@ -18,7 +18,12 @@ async function GetFromDB(req, res, notification_request_name) {
     notification_request_name +
     " AS t1 LEFT JOIN event_type AS t3 ON t1.event_id = t3.id LEFT JOIN court_type AS t4 ON t1.court_id = t4.id WHERE t1.group_id is not null";
   const result_group = await client.query(query);
-  return [...result.rows, ...result_group.rows];
+  query =
+    "SELECT t1.event_id, t1.group_id, t3.name AS event_name, t4.name AS court_name, t1.court_id FROM " +
+    notification_request_name +
+    " AS t1 LEFT JOIN event_type AS t3 ON t1.event_id = t3.id LEFT JOIN court_type AS t4 ON t1.court_id = t4.id WHERE t1.player_id is null and t1.group_id is null";
+  const result_all = await client.query(query);
+  return [...result.rows, ...result_group.rows, ...result_all.rows];
 }
 
 const NotificationRequest = async (req, res) => {


### PR DESCRIPTION
fixes https://github.com/KazutoMurase/taido-competition-record/issues/63

前回大会のフィードバックで、"競技開始時は全体に対して呼び出しをかけたいが、それを本部席(司会)にリクエストするボタンがない" といったものがあったのを忘れていました。

本PRでは、まず押したら司会用UIに通知がいく/消せる、を実装しました。

個人/団体呼び出しでサポートしている以下はまだ未対応です

- 通知がいったことが点呼UIに反映されて、二重に送信するのを抑止
- 通知をした後にキャンセルができる

![Screenshot from 2024-06-05 23-59-33](https://github.com/KazutoMurase/taido-competition-record/assets/3016693/1e49f186-544e-4a28-8c46-65084aaf4631)
![Screenshot from 2024-06-05 23-59-48](https://github.com/KazutoMurase/taido-competition-record/assets/3016693/53af28df-f0b1-4b0d-bce6-bbb76fd544e7)
