### PR TITLE
add go-to-court-top button in check_result

### DIFF
--- a/pages/admin/check_result.js
+++ b/pages/admin/check_result.js
@@ -1,5 +1,5 @@
+import Button from "@mui/material/Button";
 import React from "react";
-import { useEffect, useState } from "react";
 import GetResult from "../../components/get_result";
 import { useRouter } from "next/router";
 import { GetEventName } from "../../lib/get_event_name";
@@ -26,6 +26,21 @@ const Home = () => {
         returnUrl={return_url}
         block_number={block_number}
       />
+      <div
+        style={{
+          textAlign: "center",
+        }}
+      >
+        <Button
+          variant="contained"
+          type="submit"
+          onClick={(e) => {
+            router.push("/admin/block?block_number=" + block_number);
+          }}
+        >
+          コートメニューに戻る
+        </Button>
+      </div>
     </>
   );
 };

--- a/pages/test/check_result.js
+++ b/pages/test/check_result.js
@@ -1,5 +1,5 @@
+import Button from "@mui/material/Button";
 import React from "react";
-import { useEffect, useState } from "react";
 import GetResult from "../../components/get_result";
 import { useRouter } from "next/router";
 import { GetEventName } from "../../lib/get_event_name";
@@ -26,6 +26,21 @@ const Home = () => {
         returnUrl={return_url}
         block_number={block_number}
       />
+      <div
+        style={{
+          textAlign: "center",
+        }}
+      >
+        <Button
+          variant="contained"
+          type="submit"
+          onClick={(e) => {
+            router.push("/test/block?block_number=" + block_number);
+          }}
+        >
+          コートメニューに戻る
+        </Button>
+      </div>
     </>
   );
 };


### PR DESCRIPTION
これまでの実装で「結果修正」を行うと、結果修正画面で「決定」を押した後の画面（check_result）から「戻る」を押すと結果修正画面に、さらにそこで「戻る」を押すとcheck_result画面に...とループしてしまっていたため、コートのトップページに直接移動するためのボタンを追加しました。

もっと正攻法な解決方法もあるかもしれないとは思うので、その場合そちらを採用してくださればと思います。