### PR TITLE
fix page back loop

### DIFF
--- a/components/get_result.js
+++ b/components/get_result.js
@@ -844,6 +844,7 @@ function ShowWinner(item) {
 }
 
 function GetResult({
+  backUrl = null,
   editable = false,
   updateInterval = 10000,
   returnUrl = null,
@@ -856,7 +857,11 @@ function GetResult({
     returnUrl = event_name + "_result";
   }
   const onBack = () => {
-    router.back();
+    if (backUrl === null) {
+      router.back();
+    } else {
+      router.push(backUrl);
+    }
   };
 
   const [data, setData] = useState([]);

--- a/pages/admin/check_result.js
+++ b/pages/admin/check_result.js
@@ -6,7 +6,7 @@ import { GetEventName } from "../../lib/get_event_name";
 
 const Home = () => {
   const router = useRouter();
-  const { block_number, schedule_id, event_id } = router.query;
+  const { block_number, schedule_id, event_id, back_url } = router.query;
   if (block_number === undefined) {
     return <></>;
   }
@@ -17,7 +17,9 @@ const Home = () => {
     "%26schedule_id=" +
     schedule_id +
     "%26event_id=" +
-    event_id;
+    event_id +
+    "%26back_url=block?block_number=" +
+    block_number;
   return (
     <>
       <GetResult
@@ -25,6 +27,7 @@ const Home = () => {
         event_name={event_name}
         returnUrl={return_url}
         block_number={block_number}
+        backUrl={back_url}
       />
     </>
   );


### PR DESCRIPTION
https://github.com/KazutoMurase/taido-competition-record/pull/91 と同等の修正です

backUrlを追加して、結果修正から戻る時にループせず明示的にコートトップページに戻れるようにします