### PR TITLE
align left on block view

### DIFF
--- a/components/block.js
+++ b/components/block.js
@@ -21,8 +21,6 @@ function ShowDetails(
   if (GetEventName(item["event_id"]) === "dantai") {
     return (
       <>
-        &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp;
-        &nbsp;&nbsp;
         <Button
           variant="contained"
           type="submit"
@@ -31,8 +29,6 @@ function ShowDetails(
         >
           競技終了
         </Button>
-        &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp; &nbsp;&nbsp;
-        &nbsp;&nbsp; &nbsp;&nbsp;
       </>
     );
   }
@@ -226,7 +222,7 @@ function Block({ block_number, update_interval, return_url }) {
                   <td>
                     {"game_count" in item ? item["game_count"] + "試合" : ""}
                   </td>
-                  <td>
+                  <td style={{ textAlign: "left" }}>
                     {item["event_id"] > 0 ? (
                       <Button
                         variant="contained"


### PR DESCRIPTION
創玄杯では関係ないですが、
"点呼" / "競技終了"　だけ選択する団体法形/展開などにおいて、スマホだと表示が変になってしまっていたので修正します

before
![Screenshot from 2024-06-11 21-33-50](https://github.com/KazutoMurase/taido-competition-record/assets/3016693/d0e54eb9-b15a-436c-b33b-9fc00028d16c)

after
![Screenshot from 2024-06-11 21-33-38](https://github.com/KazutoMurase/taido-competition-record/assets/3016693/76698d0d-ad2c-4112-8dee-580faef9c719)
