### PR TITLE
shorten first round line if the number of rounds are large

### DIFF
--- a/components/get_result.js
+++ b/components/get_result.js
@@ -865,6 +865,7 @@ function GetResult({
   };
 
   const [data, setData] = useState([]);
+  const [lineWidth, setLineWidth] = useState(50);
   useEffect(() => {
     async function fetchData() {
       const response = await fetch(
@@ -872,6 +873,10 @@ function GetResult({
       );
       const result = await response.json();
       setData(result);
+      if (result.length > 0) {
+        const roundNum = result.sort((a, b) => b.round - a.round)[0].round;
+        setLineWidth(roundNum > 6 ? 25 : 50);
+      }
     }
     fetchData();
     if (updateInterval > 0) {
@@ -884,9 +889,7 @@ function GetResult({
     }
   }, [event_name, freeze, updateInterval]);
   const sortedData = data.sort((a, b) => a.id - b.id);
-  const lineWidth = 50;
   let maxHeight = 0;
-  console.log(data);
   for (let i = 0; i < data.length; i++) {
     if ("left_begin_y" in data[i] && maxHeight < data[i]["left_begin_y"]) {
       maxHeight = data[i]["left_begin_y"];


### PR DESCRIPTION
#62 の「新人法形: トーナメントの回戦が多すぎて表示バグってる」を解決しようとしてみたのですが、まだテキスト配置等の部分が読み解けておらず、だいぶ場当たり的な修正になりました。

"lineWidth"は一回戦の線の長さを決める変数かと思うのですが、マックスの回戦数が多い時にそこを短くすることで、今回の新人運足八法については決勝まで正しく表示されるようになりました（ただし慶應のように長い団体名はよりトーナメントの線と被るようになってしまいます）。

他に修正が出てこなかった時にお使いください...