### PR TITLE
add prefix to games text on progress check

### DIFF
--- a/components/progress_on_block.tsx
+++ b/components/progress_on_block.tsx
@@ -49,6 +49,19 @@ const test_event_id_vs_event_name: Map<number, string> = new Map([
   [16, "女子級位個人法形"],
 ]);
 
+function GetGamesText(schedule) {
+  if (!schedule.games_text) {
+    return "";
+  }
+  if (schedule.before_final) {
+    return "【三決】" + schedule.games_text;
+  }
+  if (schedule.final) {
+    return "【決勝】" + schedule.games_text;
+  }
+  return schedule.games_text;
+}
+
 const ProgressOnBlock: React.FC<{
   block_number: string;
   update_interval: number;
@@ -126,7 +139,7 @@ const ProgressOnBlock: React.FC<{
               </a>
             )}
           </td>
-          <td>{schedule.games_text}</td>
+          <td>{GetGamesText(schedule)}</td>
           <td>
             {isCurrentEvent
               ? games.find(


### PR DESCRIPTION
時程表の方でも、三決、決勝の場合は表示してあげるようにします。
(役員向けのブロックには既に表示されています)
