### PR TITLE
reset existing tables of database

### DIFF
--- a/pages/admin/danger_zone.js
+++ b/pages/admin/danger_zone.js
@@ -13,8 +13,12 @@ const Home = () => {
   useEffect(() => {
     fetchData();
   }, []);
-  let event_names = data?.map((item) => GetEventName(item["id"]));
-  const filtered_event_names = event_names.filter((name) => name !== "dantai");
+  let event_names = data?.map((item) => {
+    return item["existence"] ? GetEventName(item["id"]) : "";
+  });
+  const filtered_event_names = event_names.filter((name) => {
+    return name !== "dantai" && name !== "";
+  });
   // FIXME: database_name should be obtained from env
   return (
     <>


### PR DESCRIPTION
DB/キャッシュリセット機能が正しく動いていなかったので直します。
存在しないテーブルに対して処理をしてしまっていた。。
![Screenshot from 2024-06-12 09-53-08](https://github.com/KazutoMurase/taido-competition-record/assets/3016693/d72adfbf-b325-46d4-9ba5-173917f38b08)
