### PR TITLE
fix block left/right judgement when the number of games in the same r…

### DIFF
--- a/pages/api/check_players_on_block.js
+++ b/pages/api/check_players_on_block.js
@@ -171,7 +171,8 @@ async function GetFromDB(
           for (let k = 0; k < round - 1; k++) {
             game_id -= round_num[k + 1];
           }
-          if (round_num[round] % 2 === 0) {
+          // TODO: temporary fix for 2024sogenhai. change left/right judgement logic later
+          if (round_num[round] % 2 === 0 || event_name === "dantai_zissen") {
             block_pos = game_id <= round_num[round] / 2 ? "left" : "right";
           } else {
             block_pos = game_id <= round_num[round] / 2 + 1 ? "left" : "right";


### PR DESCRIPTION
…ound is odd

https://github.com/KazutoMurase/taido-competition-record/issues/62#issuecomment-2165729344 の修正です。
round_numの値の設定のロジックは追いきれなかったのですが、出てくる数字的にこれは「トーナメント中の○回戦の試合数」のArrayかと思いました。

試合番号が試合数の半分以下の時にトーナメントの左側、半分を超える時にトーナメントの右側という判定がなされていましたが、少なくとも創玄杯のトーナメントでは試合数が奇数の時に左側に1個多く試合が詰められているようです。この組み方が普遍的かは分からないので今後注意が必要ですが、~~とりあえずはこの修正で大丈夫かと思います。~~

→よく見たら団体実戦だけこの法則に従っていませんでした...ちゃんと直すなら左右ブロックどちらに存在するかを示すフラグをDBにつけなくてはならないでしょうか...