### PR TITLE
adjust left position of dantai text

### DIFF
--- a/components/get_result.js
+++ b/components/get_result.js
@@ -99,9 +99,9 @@ function CreateDantaiText(item, lineWidth, hide = false) {
       );
     }
   } else if ("fake_round" in item) {
-    const x = 220 + lineWidth + (item["fake_round"] - 2) * 30;
+    const x = 150 + lineWidth + (item["fake_round"] - 2) * 30;
     const width =
-      620 -
+      690 -
       lineWidth -
       (item["fake_round"] - 2) * 30 -
       (220 + lineWidth + (item["fake_round"] - 2) * 30);


### PR DESCRIPTION
団体実戦で左側の大学名が長くて被る場合に対して、場当たり的ですが修正しておきます

![Screenshot from 2024-06-14 10-42-36](https://github.com/KazutoMurase/taido-competition-record/assets/3016693/6edd0c4a-8b25-498b-9fb5-01c47c230679)
