### PR TITLE
query db in redis error

### DIFF
--- a/lib/redis_client.js
+++ b/lib/redis_client.js
@@ -1,11 +1,30 @@
 import { kv } from "@vercel/kv";
 import { createClient } from "redis";
 
+async function connectToRedis() {
+  let client;
+  try {
+    client = createClient();
+    client.on("error", (err) => {
+      console.log("Redis Client Error", err);
+      throw err;
+    });
+    await client.connect();
+  } catch (err) {
+    console.log("Connection Error", err);
+    throw err;
+  }
+  return client;
+}
+
 export async function Get(key) {
   if (process.env.LOCAL === "1") {
-    const client = await createClient()
-      .on("error", (err) => console.log("Redis Client Error", err))
-      .connect();
+    let client;
+    try {
+      client = await connectToRedis();
+    } catch (err) {
+      return null;
+    }
     const value = await client.get(key);
     if (value instanceof Object) {
       return JSON.parse(value);
@@ -22,9 +41,12 @@ export async function Get(key) {
 
 export async function Set(key, value) {
   if (process.env.LOCAL === "1") {
-    const client = await createClient()
-      .on("error", (err) => console.log("Redis Client Error", err))
-      .connect();
+    let client;
+    try {
+      client = await connectToRedis();
+    } catch (err) {
+      return;
+    }
     if (value instanceof Object) {
       await client.set(key, JSON.stringify(value));
     } else {


### PR DESCRIPTION
すみません、最後の最後ですが、
テストしていたら以下のようにredisへの接続でエラーが出るというのが一回発生して、
基本的に繋がるまで待つようになってしまっているのでずっとログが溢れ続けてしばらく復旧しないという事象が発生してしまいました。(Vercel KVではなくcloud run内部のredis serverと繋げているだけなのでスケールしなくて問題が起きた？)

なのでredis client側でエラーが発生した時はすぐにnullを返して、redisとの通信がうまくいかない場合はdatabaseに再度アクセスして値を返す、という変更を入れます。

localでわざとredis serverを落として動作継続することを確認しました。
![Screenshot from 2024-06-15 22-57-03](https://github.com/KazutoMurase/taido-competition-record/assets/3016693/3d43ca92-a869-4830-a234-14189f6c00d7)
