### PR TITLE
Use singleton for redis client

### DIFF
--- a/lib/redis_client.js
+++ b/lib/redis_client.js
@@ -1,18 +1,21 @@
 import { kv } from "@vercel/kv";
 import { createClient } from "redis";
 
+let client;
+
 async function connectToRedis() {
-  let client;
-  try {
-    client = createClient({ pingInterval: 10000 });
-    client.on("error", (err) => {
-      console.log("Redis Client Error", err);
+  if (!client) {
+    try {
+      client = createClient({ pingInterval: 10000 });
+      client.on("error", (err) => {
+        console.log("Redis Client Error", err);
+        client = null;
+      });
+      await client.connect();
+    } catch (err) {
+      console.log("Connection Error", err);
       throw err;
-    });
-    await client.connect();
-  } catch (err) {
-    console.log("Connection Error", err);
-    throw err;
+    }
   }
   return client;
 }


### PR DESCRIPTION
redis clientのコネクションをアクセスの度に張ってしまっていたために、コネクション数が増えすぎてもう接続ができなくなる、というのが大会中に起きていたように思います。
ローカルで再現させて、redis-cliで繋げようとしたら"maximum number of clients reached"が出て分かりました。

clientをシングルトンにしておくことで、コネクション数が増殖しないことを確認しました。
デフォルトmax値の10000は、躰道の大会規模がもっと大きくなれば増やしてもよい可能性がありますが、増殖させなければ全然大丈夫そうに思います。

メモ: redis-cliを実行して、
- config get maxclients で最大接続数の値がみれる(デフォルト10000)
- config set maxclients N で動的に変更
- infoでconnected_clientsなどの情報みられる
- 起動時に設定しておくなら/etc/redis/redis.confに

sudo systemctl restart redis-server.serviceを実行しても最初に立ち上げたサーバをkillしてくれるわけではない(これはよくない)。killを手動でやって再度立ち上げると復活。