### PR TITLE
control local database and redis server

### DIFF
--- a/.env
+++ b/.env
@@ -4,3 +4,6 @@ COMPETITION_NAME=2024_sogenhai
 # For basic authorization
 USERNAME=taido
 PASSWORD=2024sogenhai
+
+USE_LOCAL_DB="1"
+USE_LOCAL_REDIS="1"

--- a/tools/setup.bash
+++ b/tools/setup.bash
@@ -1,9 +1,11 @@
 #!/bin/bash
 competition_name=$1
 
-systemctl start redis-server.service
+if [ "${USE_LOCAL_REDIS}" == "1" ]; then
+    systemctl start redis-server.service
+fi
 
-if [ -z "${PRODUCTION}" ]; then
+if [ "${USE_LOCAL_DB}" == "1" ]; then
     /etc/init.d/postgresql start
     if sudo -u postgres psql -lqt | cut -d \| -f 1 | grep -qw taido_record; then
         echo "database already exists."
@@ -12,6 +14,10 @@ if [ -z "${PRODUCTION}" ]; then
         cd /ws/data/$competition_name && sudo -u postgres psql -d taido_record < generate_tables.sql
         cd /ws/data/test && sudo -u postgres psql -d taido_record < generate_tables.sql
     fi
+fi
+
+
+if [ -z "${PRODUCTION}" ]; then
     cd /ws && npm install && npm run dev
 else
     cd /ws && npm run start


### PR DESCRIPTION
![Screenshot from 2024-07-12 23-49-37](https://github.com/user-attachments/assets/f789c0ae-f5fa-4b84-a294-bc5a4e346911)

コンテナ内でDBとredisを立ち上げるかどうかを制御します。

今のところ
- ローカルではコンテナ内DB, redisで開発(local_db=1, local_redis=1)
- 本番で、1インスタンス運用の場合はCloud SQL + local redis(local_db=0, local_redis=1)
- 本番で、複数インスタンス運用の場合はCloud SQL + Memorystore(local_db=0, local_redis=0)
- 本番後、結果表示用にはコンテナ内DB(結果を反映), redis(local_db=1, local_redis=1)

みたいなイメージです。

Cloud上のDBやredisに繋げる場合、コンテナ内で立ち上げたままでも別に良いのですが、スケーリングが遅くなるのでフラグで制御した方がよいです。