### PR TITLE
add get_table_result and support dantai_hokei

### DIFF
--- a/pages/api/get_table_result.js
+++ b/pages/api/get_table_result.js
@@ -1,0 +1,83 @@
+import GetClient from "../../lib/db_client";
+import { Get, Set } from "../../lib/redis_client";
+
+// FIXME: need to support tenkai
+async function GetFromDB(req, res) {
+  const client = await GetClient();
+  const event_name = req.query.event_name;
+  let query;
+  const groups_name = event_name + "_groups";
+  const groups = event_name.includes("test") ? "test_groups" : "groups";
+  query =
+    "SELECT t1.id, t1.round, t1.main_score, t1.sub1_score, t1.sub2_score, t1.penalty, t1.retire, t2.name FROM " +
+    event_name +
+    " AS t1 LEFT JOIN " +
+    groups_name +
+    " AS t2 ON t1.group_id = t2.id";
+  const result_schedule = await client.query(query);
+  const sorted_data = result_schedule.rows.sort((a, b) => a.id - b.id);
+  for (let i = 0; i < sorted_data.length; i++) {
+    let sum_score = 0;
+    // Multiply by 10 before sum, then devide by 10 at last
+    // to avoid rounding error
+    if (sorted_data[i]["main_score"]) {
+      sum_score += parseFloat(sorted_data[i]["main_score"]) * 10;
+    }
+    if (sorted_data[i]["sub1_score"]) {
+      sum_score += parseFloat(sorted_data[i]["sub1_score"]) * 10;
+    }
+    if (sorted_data[i]["sub2_score"]) {
+      sum_score += parseFloat(sorted_data[i]["sub2_score"]) * 10;
+    }
+    if (sorted_data[i]["penalty"]) {
+      sum_score += parseFloat(sorted_data[i]["penalty"]) * 10;
+    }
+    sorted_data[i]["sum_score"] = sum_score ? sum_score / 10 : null;
+  }
+  const grouped_data = sorted_data.reduce((result, data) => {
+    if (!result[data.round]) {
+      result[data.round] = [];
+    }
+    result[data.round].push(data);
+    return result;
+  }, {});
+
+  const ranked_data = Object.values(grouped_data).flatMap((round_group) => {
+    round_group.sort((a, b) => {
+      if (b.sum_score === a.sum_score) {
+        return b.main_score - a.main_score;
+      }
+      return b.sum_score - a.sum_score;
+    });
+    round_group.forEach((item, index) => {
+      item.rank = item.sum_score ? index + 1 : null;
+    });
+    return round_group;
+  });
+  return ranked_data.sort((a, b) => a.id - b.id);
+}
+
+const GetResult = async (req, res) => {
+  try {
+    const event_name = req.query.event_name;
+    const latest_update_key =
+      "latest_update_result_for_" + event_name + "_timestamp";
+    const cache_key = "get_result_for_" + event_name + "_cache_data";
+    const cached_data = await Get(cache_key);
+    const latest_update_timestamp = (await Get(latest_update_key)) || 0;
+    if (cached_data && latest_update_timestamp < cached_data.timestamp) {
+      console.log("using cache");
+      return res.json(cached_data.data);
+    }
+    console.log("get new data");
+    const data = await GetFromDB(req, res);
+    console.log(data);
+    await Set(cache_key, { data: data, timestamp: Date.now() });
+    res.json(data);
+  } catch (error) {
+    console.log(error);
+    res.status(500).json({ error: "Error fetching data" });
+  }
+};
+
+export default GetResult;


### PR DESCRIPTION
団体法形用の結果取得APIを追加します。

元のをget_tournament_result (としたいですがとりあえずそのまま)、今回のは名前どうしようかと思ってテーブル形式の競技結果を取得するのでget_table_resultとすると並べられるかなと考えましたが、なんかもっと良い名前があれば提案もらえると嬉しいです。

主審、副審どこか一つでも入力があれば合計点とラウンド毎の順位をつけるようにしていて(エクセルのマクロもそうなっています)、あとは点数が並んだ時は主審の得点が優先されるようになっています。
何か他に考慮すべき基準があったか覚えていないですが、もしあれば教えてもらえると嬉しいです。


以下のようにアクセスすると、
http://localhost:3000/api/get_table_result?event_name=dantai_hokei_man

こんな感じの結果が返ってくるというのを動作確認しています(DBは手動で更新)
[{"id":1,"round":1,"main_score":6.3,"sub1_score":0.2,"sub2_score":3.2,"penalty":-0.5,"retire":null,"name":"'青森県'","sum_score":9.2,"rank":1},{"id":2,"round":1,"main_score":6.4,"sub1_score":0.1,"sub2_score":null,"penalty":null,"retire":null,"name":"'北海道'","sum_score":6.5,"rank":3},{"id":3,"round":1,"main_score":6.5,"sub1_score":0,"sub2_score":null,"penalty":null,"retire":null,"name":"'千葉県'","sum_score":6.5,"rank":2},{"id":4,"round":1,"main_score":null,"sub1_score":null,"sub2_score":null,"penalty":null,"retire":null,"name":"'東京城南'","sum_score":null,"rank":null}]