### PR TITLE
expand scroll range on mobile page

### DIFF
--- a/components/get_result.js
+++ b/components/get_result.js
@@ -1164,7 +1164,7 @@ function GetResult({
     const point = event.target.getStage().getPointerPosition();
     const deltaX = point.x - lastTouchPos;
     const nextStagePos = parseFloat(stagePos + deltaX);
-    if (nextStagePos <= 0 && nextStagePos >= -350) {
+    if (nextStagePos <= 0 && nextStagePos >= -400) {
       setStagePos(nextStagePos);
     }
     localStorage.setItem(event_name + "stagePos", stagePos);


### PR DESCRIPTION
モバイル用のトーナメントで、サイズによっては初期位置がスクロール範囲外にいる場合があり、動かせないことがあったので、範囲を広げます