### PR TITLE
submit retire on dantai hokei properly

### DIFF
--- a/pages/api/record_table.js
+++ b/pages/api/record_table.js
@@ -28,28 +28,40 @@ const RecordTable = async (req, res) => {
         req.body.sub2_score;
       initial_value_is_set = true;
     }
-    if (req.body.sub3_score || req.body.retire) {
+    if (
+      event_name.includes("tenkai") &&
+      (req.body.sub3_score || req.body.retire)
+    ) {
       query +=
         (initial_value_is_set ? "," : " ") +
         "sub3_score=" +
         req.body.sub3_score;
       initial_value_is_set = true;
     }
-    if (req.body.sub4_score || req.body.retire) {
+    if (
+      event_name.includes("tenkai") &&
+      (req.body.sub4_score || req.body.retire)
+    ) {
       query +=
         (initial_value_is_set ? "," : " ") +
         "sub4_score=" +
         req.body.sub4_score;
       initial_value_is_set = true;
     }
-    if (req.body.sub5_score || req.body.retire) {
+    if (
+      event_name.includes("tenkai") &&
+      (req.body.sub5_score || req.body.retire)
+    ) {
       query +=
         (initial_value_is_set ? "," : " ") +
         "sub5_score=" +
         req.body.sub5_score;
       initial_value_is_set = true;
     }
-    if (req.body.elapsed_time || req.body.retire) {
+    if (
+      event_name.includes("tenkai") &&
+      (req.body.elapsed_time || req.body.retire)
+    ) {
       query +=
         (initial_value_is_set ? "," : " ") +
         "elapsed_time=" +


### PR DESCRIPTION
"団法（展開も？）：記録画面での「棄権」ボタンが効かない" の修正です。

棄権ボタンの動作確認を展開でしかしてませんでした。

retireフラグがたった時に、sub3_score以下がなくてもセットしにいこうとしてしまうので、
団法のみですが棄権用のAPIがちゃんと動いていませんでした。

展開用の条件に対して、きちんとevent_nameにtenkaiが含まれているかどうかを見に行くようにします。