### PR TITLE
show games_text on dantai hokei and tenkai

### DIFF
--- a/components/block.js
+++ b/components/block.js
@@ -147,12 +147,6 @@ function ShowGamesText(item, is_mobile) {
   if (prefix !== "" && !is_mobile) {
     prefix = "【" + prefix + "】";
   }
-  if (
-    item["name"]?.includes("団体展開") ||
-    item["name"]?.includes("団体法形")
-  ) {
-    return prefix + "";
-  }
   if (is_mobile) {
     const elems = item["games_text"]?.split(",");
     if (elems) {


### PR DESCRIPTION
"admin側の画面で団体法形・展開の試合番号が出ない"　の修正です

昔は団体競技サポートしてなかった名残で消えてしまっていたので、そこの条件を削除します