### PR TITLE
reset group_id in dantai db

### DIFF
--- a/pages/api/reset_db.js
+++ b/pages/api/reset_db.js
@@ -66,7 +66,20 @@ async function UpdateEventFromCSV(client, db_name, event_name) {
 }
 
 async function UpdateTableEventFromCSV(client, db_name, event_name) {
+  const csvFilePath = path.join(
+    process.cwd(),
+    "/data/" + db_name + "/" + event_name + ".csv",
+  );
+  const fileData = fs.readFileSync(csvFilePath, "utf-8");
+  const records = await parseAsync(fileData);
   let query;
+  for (const record of records) {
+    query = {
+      text: "UPDATE " + event_name + " SET group_id = $1 WHERE id = $2",
+      values: [record.group_id ? parseInt(record.group_id) : null, record.id],
+    };
+    await client.query(query);
+  }
   if (event_name.includes("tenkai")) {
     query =
       "UPDATE " +


### PR DESCRIPTION
団体競技の、決勝進出Tのリセットがされない問題の修正です

group_idを元のcsvから見てリセットをかけます(クエリ少なくするならfinal_round_idの条件に対してnullをセットするように書けますがまぁテストしてリセットしたいときしか使わないのでクエリ多くてもよいと思います)