### PR TITLE
adjust font size of group name in third-place matches (like other games)

### DIFF
--- a/components/get_result.js
+++ b/components/get_result.js
@@ -385,7 +385,7 @@ function CreateText(item, lineWidth, y_padding, hide = false) {
               ? item["left_group_name"].replace("'", "【").replace("'", "】")
               : ""
           }
-          fontSize={14}
+          fontSize={GetGroupNameFontSize(item["left_group_name"])}
         />
         <Text
           x={x + width + 10}
@@ -411,7 +411,7 @@ function CreateText(item, lineWidth, y_padding, hide = false) {
               ? item["right_group_name"].replace("'", "【").replace("'", "】")
               : ""
           }
-          fontSize={14}
+          fontSize={GetGroupNameFontSize(item["right_group_name"])}
         />
       </>
     );


### PR DESCRIPTION
トーナメントの他の箇所で行われている団体名のフォントサイズ調整が、三位決定戦だけ抜けていたので追加しました。