### PR TITLE
check if group name exists

### DIFF
--- a/components/get_result.js
+++ b/components/get_result.js
@@ -144,6 +144,9 @@ function CreateDantaiText(item, lineWidth, y_padding, hide = false) {
 }
 
 function GetGroupNameFontSize(group_name) {
+  if (!group_name) {
+    return 10;
+  }
   if (group_name.length < 8) {
     return 14;
   }


### PR DESCRIPTION
https://github.com/KazutoMurase/taido-competition-record/pull/196 だと、三決が決まっていない段階だとgroup nameが存在しないためgroup_name.lengthにアクセスできずエラーが出てしまうので、存在しない場合はデフォルトサイズを返すようにとりあえずしておきます