### PR TITLE
hide groups that proceeds to final round in dantai-hokei/tenkai when …

### DIFF
--- a/components/get_table_result.tsx
+++ b/components/get_table_result.tsx
@@ -265,6 +265,8 @@ const GetTableResult: React.FC<{
                   <td>
                     {elem.retire && visible ? (
                       <s>{group_name}</s>
+                    ) : hide && elem.is_final ? (
+                      <></>
                     ) : (
                       <>{group_name}</>
                     )}


### PR DESCRIPTION
…PRODUCTION_TEST=1

PRODUCTION_TEST=1の時でも団法・展開の決勝進出団体だけは見えてしまっていたので隠しました（現在のデプロイ先はPRODUCTION_TEST=1でビルドしていますが、その状態です）。