### PR TITLE
Hide final groups if production test

### DIFF
--- a/components/get_table_result.tsx
+++ b/components/get_table_result.tsx
@@ -201,6 +201,8 @@ const GetTableResult: React.FC<{
                   <td>
                     {elem.retire && visible ? (
                       <s>{group_name}</s>
+                    ) : hide && elem.is_final ? (
+                      <></>
                     ) : (
                       <>{group_name}</>
                     )}


### PR DESCRIPTION
#200 で展開の方に決勝進出グループを隠す変更を加え忘れていたので、修正しました。