### PR TITLE
show summary from admin page

### DIFF
--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -24,7 +24,7 @@ export default function Home({ params }) {
     router.push("/admin/notification_request");
   };
   const ToSummary = () => {
-    router.push("/summary");
+    router.push("/summary?from_admin=true");
   };
   const ToTotal = () => {
     router.push("/total");

--- a/pages/summary.tsx
+++ b/pages/summary.tsx
@@ -20,7 +20,8 @@ const Summary: React.FC<{ params }> = ({ params }) => {
   const ToBack = () => {
     router.back();
   };
-  const hide = params.production_test === "1";
+  const { from_admin } = router.query;
+  const hide = params.production_test === "1" && !from_admin;
   const [data, setData] = useState([]);
 
   const fetchData = async () => {


### PR DESCRIPTION
PRODUCTION_TEST=1の時、adminから見るsummaryも結果が何も見えていなくてデバッグや確認が辛いと思うので、from_adminがセットされているときはsummaryの中身が見れるようにします