### PR TITLE
fix target id error in confirm-table result

### DIFF
--- a/pages/api/get_table_result.js
+++ b/pages/api/get_table_result.js
@@ -117,11 +117,11 @@ const GetResult = async (req, res) => {
     const latest_update_timestamp = (await Get(latest_update_key)) || 0;
     if (cached_data && latest_update_timestamp < cached_data.timestamp) {
       console.log("using cache");
-      //return res.json(cached_data.data);
+      return res.json(cached_data.data);
     }
     console.log("get new data");
     const data = await GetFromDB(req, res);
-    console.log(data);
+    // console.log(data);
     await Set(cache_key, { data: data, timestamp: Date.now() });
     res.json(data);
   } catch (error) {


### PR DESCRIPTION
2024年学生大会で起きた、「展開（・団法）の決勝進出チームが書き換わってしまう」というエラーの修正です。

まず、このエラーは「決勝までの採点結果を入れてから、『結果確定』ボタンを押す」ことで発生することがあります。
再現しやすいように、2024年学生大会の午前中まで終わった時点のデータを以下にアップロードしておきます。
[1250_export.zip](https://github.com/user-attachments/files/17372186/1250_export.zip)

原因の細かい部分まではつかみきれていないのですが、
- 予選の順位をチェックして決勝進出チームを決める所で、決勝の順位も影響してしまっている？
- 決勝の試合IDを計算する式が微妙にずれてしまう？

あたりが原因かと思っていて、この修正を適用すると、決勝の点数を入れた後に「結果確定」ボタンを押してしまったとしても、新人団法（予選が2ブロックに分かれている）・男女展開（予選が1ブロックだけ）ともに決勝進出チームが正しくなることを確認しました。

ただ元の原因をしっかり把握しきれていないので、この修正が正しいか、他の方のチェックも経てからマージしたいと思っております。よろしくお願いします。