### PR TITLE
fix target_id error in confirm table result

### DIFF
--- a/pages/api/confirm_table_result.js
+++ b/pages/api/confirm_table_result.js
@@ -87,7 +87,10 @@ const Confirm = async (req, res) => {
   if (final_round_num > 1) {
     const winners_num =
       grouped_data[final_round_num].length / (final_round_num - 1);
-    const final_round_start_id = grouped_data[final_round_num][0].id;
+    // ranked_data might collapse the order, need to sort again
+    const final_round_start_id = grouped_data[final_round_num].sort(
+      (a, b) => a.id - b.id,
+    )[0].id;
     for (let i = 1; i < final_round_num; i++) {
       const data = grouped_data[i];
       for (const item of data) {

--- a/pages/api/get_table_result.js
+++ b/pages/api/get_table_result.js
@@ -117,11 +117,10 @@ const GetResult = async (req, res) => {
     const latest_update_timestamp = (await Get(latest_update_key)) || 0;
     if (cached_data && latest_update_timestamp < cached_data.timestamp) {
       console.log("using cache");
-      //return res.json(cached_data.data);
+      return res.json(cached_data.data);
     }
     console.log("get new data");
     const data = await GetFromDB(req, res);
-    console.log(data);
     await Set(cache_key, { data: data, timestamp: Date.now() });
     res.json(data);
   } catch (error) {


### PR DESCRIPTION
https://github.com/KazutoMurase/taido-competition-record/pull/214 を元に、原因調査し簡易修正を試みるPRです。

ranked_dataを計算するところで、元々grouped_dataをidでソートしていたところが崩れてしまい、この影響としては

1.決勝のところの結果が入力されていると決勝のroundにおけるid順のソートが崩れる
2.final_round_start_idが指してほしいところを指さなくなる
3.group_idに対して適切なtarget_idを更新しなくなる

ということが発生するのが根本原因だと思います。

なので、final_round_start_idを計算するところで、
もう一度id順にsortしてあげる手続きを入れることで問題解決しそうです