### PR TITLE
add update db api

### DIFF
--- a/pages/api/update_db.js
+++ b/pages/api/update_db.js
@@ -1,0 +1,21 @@
+import GetClient from "../../lib/db_client";
+
+const UpdateDb = async (req, res) => {
+  try {
+    const client = await GetClient();
+    const table_name = req.query.table_name;
+    const id = req.query.id;
+    const key = req.query.key;
+    const value = req.query.value;
+    await client.query({
+      text: "UPDATE " + table_name + " SET " + key + " = $1 WHERE id = $2",
+      values: [value, id],
+    });
+    res.json([]);
+  } catch (error) {
+    console.log(error);
+    res.status(500).json({ error: "Error fetching data" });
+  }
+};
+
+export default UpdateDb;


### PR DESCRIPTION
取り急ぎ、前大会でバグによりデータベース直接書き換えが必要になる事案が発生したので、
GCPにsshしてDBにアクセスしなくても、APIから書き換えが可能な口を一つ作っておきます。

以下のように、ID指定、テーブル名と書き換えたいフィールドのkeyとvalueを一つ指定できるだけのものです。
http://localhost:3000/api/update_db?id=1&table_name=block_a&key=players_checked&value=1
curl -X GET "..."

SQLインジェクション全く対策していないのでよくないのですが、自分のものではないGCP環境を使って実施する来週の大会までにとりあえずさっと準備しておきたかったので