### PR TITLE
partially support new xlsx layout 

### DIFF
--- a/scripts/generate_tournament_db_from_xl.py
+++ b/scripts/generate_tournament_db_from_xl.py
@@ -223,7 +223,7 @@ def search_right_block(sheet, games, game, row, col):
                     value = sheet[row - update_row - 1][col + update_col + i].value
                     if isinstance(value, float):
                         game.right_id = int(value)
-            if game.left_id == "":
+            if game.right_id == "":
                 print (f"failed to find next upper item in {sheet[row][col]}")
         else:
             for i in range(4):


### PR DESCRIPTION
創玄杯のxlsxフォーマットが今までと大きく変わっておりそのままではスクリプトが使えない。
以下の改変を行えば対応可能なようにした

1. 選手番号を内側から外側にずらす
2. 決勝のところを左右1セルではなく2セル分に拡張 (決勝とその番号は2セル分のマージ) 
の変更

- border.(left|right|top|bottom)が基本全てのセルに元々存在していたのがNoneが設定されることがある
- 数字が整数でなくfloatで入っている
- IFマクロを使って選手名など元々引っ張ってきていたがそのまま値が埋め込まれている => 選手IDを左右セル4つ分探しに行く