### PR TITLE
fix: CI Buildが失敗する原因を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ book/
 
 # service account json key
 key.json
+cloud-sql-proxy
+
+# venv for generate db script
+venv/

--- a/ci/.env
+++ b/ci/.env
@@ -8,7 +8,8 @@ COMPETITION_NAME="2025_sogenhai"
 # cloudbuild.yamlの作成段階で任意に設定できるビルド結果イメージの名前
 IMAGE_NAME="taido-competition-record"
 # cloudbuild.yamlの作成段階で任意に設定できるCloud Runの名前。最終的なHPのURLに現れるので注意。
-CLOUD_RUN_DEPLOY_NAME="2025-sogenhai"
+# 数字始まりでは設定できない
+CLOUD_RUN_DEPLOY_NAME="taido-competition-record"
 # ローカルのredisを使う場合は”localhost”、Memorystoreを使う場合はそのIPアドレス（Memorystoreコンソールの「プライマリエンドポイント」のところで確認できる）
 REDISHOST="localhost"
 # ローカルのredisを使う場合は”1”、Memorystoreを使う場合は”0”

--- a/ci/cloudbuild_sogenhai.yaml
+++ b/ci/cloudbuild_sogenhai.yaml
@@ -21,7 +21,7 @@ steps:
       [
         'run',
         'deploy',
-        '2025-sogenhai',
+        'taido-competition-record',
         '--image',
         'asia-northeast1-docker.pkg.dev/sogenhai/ar-docker-repo/taido-competition-record',
         '--region',

--- a/doc/develop/deploy.md
+++ b/doc/develop/deploy.md
@@ -66,7 +66,7 @@ GCPコンソールからArtifact Registryを開き、Dockerリポジトリを作
 - モード: 標準
 - ロケーションタイプ: リージョン asia-northeast1
 - 説明: 大会名が区別できるように適宜
-- 不変のイメージタグ: 有効
+- 不変のイメージタグ: 無効
 
 ## 4. Cloud SQL インスタンスの作成
 GCPコンソールからCloud SQLを開き、インスタンスを作成する
@@ -112,7 +112,7 @@ GCPコンソールを開き、Cloud Buildから接続済みのリポジトリを
 
 ## 8. 初回イメージの手動ビルドとpush
 Cloud Buildのトリガーの動作前に、Cloud Runへのデプロイに必要なDockerイメージをArtifact Registryに一度手動でpushする。
-($IMAGE_NAMEは手順5で.envファイルに設定したイメージ名)
+($IMAGE_NAME, $CLOUD_RUN_DEPLOY_NAMEは手順5で.envファイルに設定したイメージ名)
 
 ```bash
 gcloud auth configure-docker asia-northeast1-docker.pkg.dev
@@ -121,13 +121,15 @@ docker push asia-northeast1-docker.pkg.dev/$PROJECT_ID/$ARTIFACT_REGISTRY_REPO_N
 ```
 
 ## 9. Cloud Run公開アクセスの許可
+手動で一度デプロイしておく。リソース設定はCI buildで追って反映させる。
 ```bash
 # Cloud Run サービスの初回デプロイ
-gcloud run deploy $IMAGE_NAME \
+gcloud run deploy $CLOUD_RUN_DEPLOY_NAME \
   --image=asia-northeast1-docker.pkg.dev/$PROJECT_ID/$ARTIFACT_REGISTRY_REPO_NAME/$IMAGE_NAME \
   --region=asia-northeast1 \
   --platform=managed \
   --allow-unauthenticated
+  --update-env-vars PRODUCTION=1 \
 ```
 成功すると以下のように表示され、サービスにアクセスするためのURLが確認できる。
 ```


### PR DESCRIPTION
## 概要
- CIでのdeployに失敗していた

## 修正点
- Artifact registryはimmutableにしない（tagにcommit hashを含めるなどの工夫が必要なので一旦SKIP）
- CLOUD_RUN_DEPLOY_NAMEには暗黙的に設定不可な値があることがわかったので変更（数字始まりはNG）