### PR TITLE
fix duplicated sync view element

### DIFF
--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -149,23 +149,6 @@ export default function Home({ params }) {
             </>
           )}
         </Grid>
-        <br />
-        <br />
-        <br />
-        <br />
-        <Grid container justifyContent="center">
-          {hide ? (
-            <>
-              一般公開用ページへの結果反映：<b>OFF</b>
-              <SyncDisabledIcon color="disabled" />
-            </>
-          ) : (
-            <>
-              一般公開用ページへの結果反映：<b>ON</b>
-              <SyncIcon color="primary" />
-            </>
-          )}
-        </Grid>
       </Container>
     </div>
   );


### PR DESCRIPTION
どこかのマージミスで、「一般公開用のページ反映」がダブっていたので１つ消します