### PR TITLE
Fix document: database initialization

### DIFF
--- a/doc/develop/deploy.md
+++ b/doc/develop/deploy.md
@@ -141,7 +141,7 @@ Service URL: https://$IMAGE_NAME-$ランダムなハッシュ値-uc.a.run.app
 ## 10. CloudSQLの初期テーブル作成
 - ローカルにpsqlをインストール
 
-例: Ubuntu
+例: Ubuntu22.04
 ```bash
 sudo apt install postgresql-client-common postgresql-client-14
 ```


### PR DESCRIPTION
(よくはないのですが)現状テスト用DBが本番用のevent_typeフィールドに紐付いてしまっており、
test用DBから更新かけようとすると失敗するので、順序切り替え

後は諸々セットアップや更新時に必要だったところを追加しています