### PR TITLE
Set smaller line width if roundNum is not obtained

### DIFF
--- a/components/get_result.js
+++ b/components/get_result.js
@@ -925,7 +925,7 @@ function GetResult({
       setData(result);
       if (result.length > 0) {
         const roundNum = result.sort((a, b) => b.round - a.round)[0].round;
-        setLineWidth((!roundNum || roundNum) > 6 ? 25 : 50);
+        setLineWidth((!roundNum || roundNum > 6) ? 25 : 50);
       }
     }
     fetchData();


### PR DESCRIPTION
SafariでroundNum>6の条件に入らなかった？ような挙動をしていたので、
とりあえずroundNumがとれなかったら小さめのサイズをセットしておきます