### PR TITLE
fix a way of getting round num

### DIFF
--- a/components/get_result.js
+++ b/components/get_result.js
@@ -924,7 +924,9 @@ function GetResult({
       const result = await response.json();
       setData(result);
       if (result.length > 0) {
-        const roundNum = result.sort((a, b) => b.round - a.round)[0].round;
+        const roundNum = Math.max(
+          ...result.map((d) => Number(d.round)).filter((n) => !isNaN(n)),
+        );
         setLineWidth(roundNum > 6 ? 25 : 50);
       }
     }


### PR DESCRIPTION
おそらく三決のfake_roundが混ざっていた影響で、round numの取得のところがsafariのあるバージョンだと適切に行えず、round num = 6となって表示が壊れてしまっていました
roundがないところはフィルタして適切に最大roundを評価できるようにします