### PR TITLE
add database switch document

### DIFF
--- a/doc/admin/export.md
+++ b/doc/admin/export.md
@@ -10,3 +10,20 @@ tools/export.bash (URL)
 
 躰道公式サイトに載せている最終結果は、各競技結果ページにおいて
 印刷出力(e.g. Ctrl+Pを押下 => "Save as pdf" を選択し保存)を行い、FTP経由でアップロードする。
+
+
+## 大会終了後
+
+最終結果CSVをエクスポートし終えたら、data/(大会名)/resultをコミットする。
+
+cloudbuild_$PROJECT_ID.yamlを編集しコミットする(Docker内DB接続に切り替わる)。
+
+- add-cloudsql-instances項目を削除
+- PGSQL\_DATABASE=taido\_recordに変更
+- PGSQL\_HOST=localhostに変更
+- USE\_LOCAL\_DB=1に変更
+
+Cloud SQLを削除する(一日で700円台消費されるので早めに)。
+
+1. 編集 -> インスタンスの削除を防止する　のチェックを外して保存
+2. 削除


### PR DESCRIPTION
Cloud SQLが結構お金かかるので、大会終了後速やかにDocker内ローカルDBに切り替える必要があります。
その手順について記載しておきます。