### PR TITLE
adjust height of competition title header

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -80,7 +80,7 @@ export default function Home({ competitionTitle, show_total, topImagePath }) {
           container
           justifyContent="center"
           alignItems="center"
-          style={{ height: "100px" }}
+          style={{ height: "130px" }}
         >
           <h2 className="competition-title">
             <u>{competitionTitle}</u>


### PR DESCRIPTION
少年少女・高校生大会のタイトルが長く3行になるとスマホ表示がリストと被ってしまうので、少し広げます