### PR TITLE
adjust height in total page

### DIFF
--- a/pages/total.tsx
+++ b/pages/total.tsx
@@ -307,7 +307,7 @@ const Total: React.FC<{ params }> = ({ params }) => {
                 {data.map((elem) => {
                   return (
                     <tr key={elem.id}>
-                      <td style={{ padding: 1 }}>
+                      <td className={checkStyles.total}>
                         {elem.name?.replace(/['"]+/g, "")}
                       </td>
                       {event_ids.map((id) => {

--- a/styles/checks.module.css
+++ b/styles/checks.module.css
@@ -39,6 +39,7 @@
   padding: 1px 0;
   text-align: right;
   padding-right: 0.5em;
+  line-height: 0.8;
 }
 
 .total_winner {


### PR DESCRIPTION
総合得点表のテーブル各要素の高さが、得点が入っているところと入っていないところでずれてしまっているので、
高さを一律に揃えます