### PR TITLE
adjust position of right group name

### DIFF
--- a/components/get_result.js
+++ b/components/get_result.js
@@ -458,7 +458,7 @@ function CreateText(
           fontSize={12}
         />
         <Text
-          x={x + width + 120}
+          x={x + width + 130}
           y={item["left_begin_y"] - 5 + y_padding}
           text={
             item["right_group_name"] !== null && !hide


### PR DESCRIPTION
３決トーナメントの団体名のところが名前に対し十分な余白なく被ってしまうケースがあったので少し調整します