### PR TITLE
fix cache is not properly used for current block

### DIFF
--- a/pages/api/current_block.js
+++ b/pages/api/current_block.js
@@ -250,7 +250,8 @@ const CurrentBlock = async (req, res) => {
     const block_name = "block_" + req.query.block_number;
     const current_block_name = "current_" + block_name;
     const event_name = req.query.event_name;
-    const cacheKey = "current_" + block_name;
+    const cacheKey =
+      "current_" + block_name + (event_name ? "_for_" + event_name : "");
     const cachedData = await Get(cacheKey);
 
     // 'update_id_for_' +current_block_name can be checked,
@@ -283,7 +284,7 @@ const CurrentBlock = async (req, res) => {
     }
     console.log("get new data");
     const data = await GetFromDB(req, res);
-    if (data.length !== 0) {
+    if (req.query.schedule_id === undefined || data.length !== 0) {
       await Set(cacheKey, { data: data, timestamp: Date.now() });
     }
     res.json(data);


### PR DESCRIPTION
https://github.com/KazutoMurase/taido-competition-record/pull/290
でget_resultにcurrent_block api呼び出しを追加しましたが、これが例えばblockと関係ない競技のトーナメントを見るときに、空が返ってきてしまう -> 空なのでキャッシュされず、延々とDBアクセスしようとする、というバグを混入してしまい負荷をあげていました。

本PRでは、
1 . cache keyにevent_nameを入れる
2. 上記追加したapi呼び出し(schedule id指定がない)においては空でもキャッシュする

という変更を入れることで、キャッシュが適切に残りDBアクセスを減らせるようにします