### PR TITLE
fix back button loop in record page

### DIFF
--- a/pages/admin/record_result.js
+++ b/pages/admin/record_result.js
@@ -82,6 +82,7 @@ const Home = () => {
             returnUrl={return_url}
             block_number={block_number}
             fromAdmin={true}
+            backUrl={"block?block_number=" + block_number}
           />
         </>
       )}


### PR DESCRIPTION
記録UIの下のトーナメントのところから更新をかけたら戻るボタンでblock毎TOPページに戻れなくなっていたのを修正します