### PR TITLE
Fix how to update awards

### DIFF
--- a/doc/develop/utility.md
+++ b/doc/develop/utility.md
@@ -41,7 +41,7 @@ curl (URL)/api/update_current_schedule?block=a&schedule_id=5
 
 ```bash
 # 選手名で更新
-curl (URL)/api/record_awards?id=1&name=(選手名)
+curl "http://localhost:3000/api/record_awards?id=1&player_id=$(git grep "選手名" | cut -d":" -f2 | cut -d"," -f1)"
 # 選手IDで更新
 curl (URL)/api/record_awards?id=1&player_id=1
 ```


### PR DESCRIPTION
curlで全角文字入りの選手名指定でAPIたたいて褒章登録がうまくできなかったので、player_idを引っ張ってくる形で設定する方法をひとまずdocに記載修正