### PR TITLE
disable record button in no select

### DIFF
--- a/components/record_result.js
+++ b/components/record_result.js
@@ -491,6 +491,9 @@ function RecordResult({
             <Button
               variant="contained"
               type="submit"
+              disabled={
+                selectedRadioButton === null && initialRadioButton === null
+              }
               onClick={(e) =>
                 onSubmit(
                   data,


### PR DESCRIPTION
記録において選択してないのに決定ボタンを間違って押して、１つ飛ばしで進行してしまったことがあったので、
選択がない時には決定ボタンは押せないようにします