### PR TITLE
add cloudbuild taido-event CI

### DIFF
--- a/ci/.env
+++ b/ci/.env
@@ -1,10 +1,10 @@
 # .env.deploy
 # 設定値はREADMEのGCP環境へのデプロイ方法を参照
-PROJECT_ID="sogenhai"
+PROJECT_ID="taido-event"
 ARTIFACT_REGISTRY_REPO_NAME="ar-docker-repo"
 CLOUDSQL_INSTANCE_ID="postgres-instance"
 # /data/以下の今大会のディレクトリ名
-COMPETITION_NAME="2025_sogenhai"
+COMPETITION_NAME="2025_adult"
 # cloudbuild.yamlの作成段階で任意に設定できるビルド結果イメージの名前
 IMAGE_NAME="taido-competition-record"
 # cloudbuild.yamlの作成段階で任意に設定できるCloud Runの名前。最終的なHPのURLに現れるので注意。

--- a/ci/cloudbuild_taido-event.yaml
+++ b/ci/cloudbuild_taido-event.yaml
@@ -1,0 +1,83 @@
+steps:
+  - name: gcr.io/cloud-builders/git
+    args:
+      - submodule
+      - update
+      - --init
+      - --recursive
+
+  - name: gcr.io/cloud-builders/docker
+    args:
+      [
+        'build',
+        '-t',
+        'asia-northeast1-docker.pkg.dev/taido-event/ar-docker-repo/taido-competition-record',
+        '.'
+      ]
+
+  - name: gcr.io/cloud-builders/docker
+    args:
+      [
+        'push',
+        'asia-northeast1-docker.pkg.dev/taido-event/ar-docker-repo/taido-competition-record'
+      ]
+
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    args:
+      [
+        'run',
+        'deploy',
+        'taido-competition-record',
+        '--image',
+        'asia-northeast1-docker.pkg.dev/taido-event/ar-docker-repo/taido-competition-record',
+        '--region',
+        'asia-northeast1',
+        '--allow-unauthenticated',
+        '--port',
+        '3000',
+        '--memory',
+        '4Gi',
+        '--cpu',
+        '4',
+        '--cpu-boost',
+        '--no-cpu-throttling',
+        '--max-instances',
+        '1',
+        '--min-instances',
+        '0',
+        '--add-cloudsql-instances',
+        'taido-event:asia-northeast1:postgres-instance',
+        '--update-env-vars',
+        'COMPETITION_NAME=2025_adult',
+        '--update-env-vars',
+        'PGSQL_DATABASE=taido_record',
+        '--update-env-vars',
+        'PGSQL_HOST=localhost',
+        '--update-env-vars',
+        'PGSQL_PASSWORD=postgres',
+        '--update-env-vars',
+        'PGSQL_USER=postgres',
+        '--update-env-vars',
+        'PRODUCTION=1',
+        '--update-env-vars',
+        'PRODUCTION_TEST=0',
+        '--update-env-vars',
+        'REDISHOST=localhost',
+        '--update-env-vars',
+        'REDISPORT=6379',
+        '--update-env-vars',
+        'USE_LOCAL_DB=1',
+        '--update-env-vars',
+        'USE_LOCAL_REDIS=1',
+        '--update-env-vars',
+        'USERNAME=adult',
+        '--update-env-vars',
+        'PASSWORD=saitama2508'
+      ]
+
+images:
+  - asia-northeast1-docker.pkg.dev/taido-event/ar-docker-repo/taido-competition-record
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/doc/develop/deploy.md
+++ b/doc/develop/deploy.md
@@ -84,7 +84,7 @@ CIにおいて実行する内容を定義するyamlファイルを作成する�
 
 - ./ci/.envに必要な変数を記入して、以下を実行する。
 ```
-./ci/generate-cloudbuild.sh
+cd ci && ./generate-cloudbuild.sh
 ```
 
 - `cloudbuild_$PROJECT_ID.yaml`というファイルが生成される。


### PR DESCRIPTION
projectをいちいち作り直すのも大変なので、
taido-eventという汎用的な名前のプロジェクトIDを作成しました。
そこへ、ひとまずDB非接続の設定を追加します。

またデプロイ手続きのドキュメントを少し修正します