### PR TITLE
pull image from docker registry

### DIFF
--- a/doc/develop/develop.md
+++ b/doc/develop/develop.md
@@ -3,19 +3,27 @@
 ## 必要な環境
 
 * Docker
+* Git
 
 ## 手順
 
-以下のコマンドを本レポジトリのルートで実行しビルドする。
+以下の手順は本レポジトリのルートで実行する想定で記載している。
 
+dataを取得する。
 ```bash
-docker build -t taido-competition-record .
+git submodule update --init --recursive
 ```
 
-出来たイメージを使ってコンテナを立ち上げる。
+コンテナを立ち上げる(最初、イメージがローカルに存在しない場合はDockerレジストリから取得される)。
 
 ```bash
 docker compose up
+```
+
+(Optional) 自前でイメージをビルドし使ってもよい。
+
+```bash
+docker build -t ghcr.io/kazutomurase/taido-competition-record .
 ```
 
 ポート被りが無ければ、http://localhost:3000 でアクセスできる。

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "2.4"
 
 services:
   app:
-    image: "taido-competition-record:latest"
+    image: "ghcr.io/kazutomurase/taido-competition-record:latest"
     env_file:
       - .env
     ports:


### PR DESCRIPTION
イメージを本レポジトリで作成しオープンに取得できるようになったので、自前ビルドではなくそちらを使った手順に変更します