### PR TITLE
show retire immediately on check_player_on_block page

### DIFF
--- a/pages/admin/check_players_on_block.js
+++ b/pages/admin/check_players_on_block.js
@@ -197,6 +197,7 @@ const Home = () => {
                   event_name={event_name}
                   block_number={block_number}
                   is_mobile={isMobile}
+                  fromAdmin={true}
                 />
               )}
             </Box>
@@ -213,6 +214,7 @@ const Home = () => {
               updateInterval={3000}
               event_name={event_name}
               block_number={block_number}
+              fromAdmin={true}
             />
           </>
         )}


### PR DESCRIPTION
点呼UIでも棄権選手情報が即座にトーナメントに反映されるようにします