### PR TITLE
Set next color in retirement

### DIFF
--- a/components/check_players_on_block.js
+++ b/components/check_players_on_block.js
@@ -280,12 +280,23 @@ function CheckPlayers({
                 {is_mobile ? <></> : <th></th>}
               </tr>
               {data.items?.map((item, index) => (
-                <tr key={item["id"]} className={checkStyles.column}>
+                <tr
+                  key={item["id"]}
+                  className={
+                    item["retire"] === 1
+                      ? checkStyles.column_retire
+                      : checkStyles.column
+                  }
+                >
                   <td>
-                    <SquareTwoToneIcon
-                      sx={{ fontSize: squareColorFontSize }}
-                      htmlColor={item["color"] === "red" ? "red" : "gray"}
-                    />
+                    {item["retire"] === 1 ? (
+                      ""
+                    ) : (
+                      <SquareTwoToneIcon
+                        sx={{ fontSize: squareColorFontSize }}
+                        htmlColor={item["color"] === "red" ? "red" : "gray"}
+                      />
+                    )}
                   </td>
                   <td>
                     {is_mobile ? (

--- a/pages/api/check_players_on_block.js
+++ b/pages/api/check_players_on_block.js
@@ -261,6 +261,21 @@ async function GetFromDB(
                 break;
               }
             }
+            let color =
+              block_pos === "left" || block_pos === "center" ? "red" : "white";
+            if (sorted_data[j].right_retire === 1) {
+              if (sorted_data[j].next_left_id !== null) {
+                color =
+                  block_pos === "left" || block_pos === "center"
+                    ? "red"
+                    : "white";
+              } else if (sorted_data[j].next_right_id !== null) {
+                color =
+                  block_pos === "left" || block_pos === "center"
+                    ? "white"
+                    : "color";
+              }
+            }
             result_array.push({
               id: left_id,
               game_id: sorted_data[j].id,
@@ -269,10 +284,7 @@ async function GetFromDB(
               name: data[i].left_name,
               name_kana: data[i].left_name_kana,
               requested: requested,
-              color:
-                block_pos === "left" || block_pos === "center"
-                  ? "red"
-                  : "white",
+              color: color,
             });
           }
         }
@@ -301,6 +313,21 @@ async function GetFromDB(
                 break;
               }
             }
+            let color =
+              block_pos === "left" || block_pos === "center" ? "white" : "red";
+            if (sorted_data[j].left_retire === 1) {
+              if (sorted_data[j].next_left_id !== null) {
+                color =
+                  block_pos === "left" || block_pos === "center"
+                    ? "red"
+                    : "white";
+              } else if (sorted_data[j].next_right_id !== null) {
+                color =
+                  block_pos === "left" || block_pos === "center"
+                    ? "white"
+                    : "color";
+              }
+            }
             result_array.push({
               id: right_id,
               game_id: sorted_data[j].id,
@@ -309,10 +336,7 @@ async function GetFromDB(
               name: data[i].right_name,
               name_kana: data[i].right_name_kana,
               requested: requested,
-              color:
-                block_pos === "left" || block_pos === "center"
-                  ? "white"
-                  : "red",
+              color: color,
             });
           }
         }

--- a/pages/api/check_players_on_block.js
+++ b/pages/api/check_players_on_block.js
@@ -273,7 +273,7 @@ async function GetFromDB(
                 color =
                   block_pos === "left" || block_pos === "center"
                     ? "white"
-                    : "color";
+                    : "red";
               }
             }
             result_array.push({
@@ -325,7 +325,7 @@ async function GetFromDB(
                 color =
                   block_pos === "left" || block_pos === "center"
                     ? "white"
-                    : "color";
+                    : "red";
               }
             }
             result_array.push({

--- a/styles/checks.module.css
+++ b/styles/checks.module.css
@@ -8,6 +8,12 @@
   height: 50px;
 }
 
+.column_retire {
+  font-size: 20px;
+  height: 50px;
+  background: #999999;
+}
+
 .elem {
   text-align: center;
   vertical-align: middle;


### PR DESCRIPTION
点呼時に考慮されている試合において、相手選手が棄権の場合に、次の試合の赤白を考慮して表示を切り替えるようにし、
また棄権選手のところは灰色でハッチをかけ赤白表示を消すようにします。

棄権選手が多すぎて２回戦分繰り上がりの時は考慮できていないですが、とりあえずはよいかなと思います