### PR TITLE
set seed players from total/lastyear/group rank

### DIFF
--- a/scripts/generate_tournament_csv.py
+++ b/scripts/generate_tournament_csv.py
@@ -10,7 +10,7 @@ if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
 from tournament_game_builder import Game, build_games, build_games_from_slots
-from tournament_player_placement import RandomPlacementStrategy
+from tournament_player_placement import RandomPlacementStrategy, SmartSeedPlacementStrategy
 
 
 HEADER = [
@@ -264,6 +264,26 @@ def player_ids_from_rows(rows, player_column):
     ]
 
 
+def placement_players_from_rows(rows, event_name):
+    player_column = f"{event_name}_player_id"
+    return [
+        {
+            "player_id": clean_player_id(row.get(player_column, "")),
+            "rank_group": clean_integer(row.get(f"{event_name}_rank_group", "")),
+            "rank_lastyear": clean_integer(row.get(f"{event_name}_rank_lastyear", "")),
+            "rank_total": clean_integer(row.get(f"{event_name}_rank_total", "")),
+        }
+        for row in rows
+        if clean_player_id(row.get(player_column, ""))
+    ]
+
+
+def create_placement_strategy(args, rng):
+    if args.placement == "random":
+        return RandomPlacementStrategy(rng)
+    return SmartSeedPlacementStrategy(rng)
+
+
 def generate_from_source_csvs(args):
     source_tables = [read_players_table(path) for path in args.source_csv]
     event_names = source_event_names(source_tables)
@@ -278,23 +298,22 @@ def generate_from_source_csvs(args):
     print(f"wrote {static_sql}")
 
     rng = random.Random(args.seed)
-    placement_strategy = RandomPlacementStrategy(rng)
+    placement_strategy = create_placement_strategy(args, rng)
     generated_event_names = []
     for event_name in event_names:
-        player_column = f"{event_name}_player_id"
-        player_ids = player_ids_from_rows(output_rows, player_column)
-        if len(player_ids) < 2:
-            print(f"skipped {event_name} ({len(player_ids)} players)", file=sys.stderr)
+        players = placement_players_from_rows(output_rows, event_name)
+        if len(players) < 2:
+            print(f"skipped {event_name} ({len(players)} players)", file=sys.stderr)
             continue
 
-        slot_players = placement_strategy.build_slot_players(player_ids)
+        slot_players = placement_strategy.build_slot_players(players)
         games = build_games_from_slots(slot_players)
         output_csv = Path("data") / args.competition / "original" / f"{event_name}.csv"
 
         output_csv.parent.mkdir(parents=True, exist_ok=True)
         with output_csv.open("w", encoding="utf-8", newline="") as f:
             write_games(games, f)
-        print(f"wrote {output_csv} ({len(player_ids)} players, {len(games)} rows)")
+        print(f"wrote {output_csv} ({len(players)} players, {len(games)} rows)")
         generated_event_names.append(event_name)
 
     original_sql = Path("data") / args.competition / "original" / "generate_tables.sql"
@@ -334,6 +353,12 @@ def parse_args():
         help="build static/players.csv and all individual tournaments from one or more source CSVs",
     )
     parser.add_argument("--players-csv", type=Path, help="override players.csv path")
+    parser.add_argument(
+        "--placement",
+        choices=("smart", "random"),
+        default="smart",
+        help="player placement strategy (default: smart)",
+    )
     parser.add_argument("--seed", type=int, help="random seed for reproducible shuffling")
     return parser.parse_args()
 

--- a/scripts/tournament_player_placement.py
+++ b/scripts/tournament_player_placement.py
@@ -11,8 +11,16 @@ class TournamentSlot:
     occupied: bool = True
 
 
+@dataclass
+class PlacementPlayer:
+    player_id: str
+    rank_group: str = ""
+    rank_lastyear: str = ""
+    rank_total: str = ""
+
+
 class PlacementStrategy:
-    def build_slot_players(self, player_ids):
+    def build_slot_players(self, players):
         raise NotImplementedError
 
 
@@ -72,6 +80,14 @@ def assign_players_to_slots(slots, player_ids):
     return slots
 
 
+def assign_players_to_open_slots(slots, player_ids):
+    assigned_players = iter(player_ids)
+    for slot in slots:
+        if slot.occupied and not slot.player_id:
+            slot.player_id = next(assigned_players)
+    return slots
+
+
 def slot_player_ids(slots):
     return [slot.player_id for slot in slots]
 
@@ -87,10 +103,89 @@ class RandomPlacementStrategy(PlacementStrategy):
     def __init__(self, rng=None):
         self.rng = rng or random.Random()
 
-    def build_slot_players(self, player_ids):
-        shuffled_player_ids = list(player_ids)
+    def build_slot_players(self, players):
+        shuffled_player_ids = [player_id_from_entry(player) for player in players]
         self.rng.shuffle(shuffled_player_ids)
         return build_slot_players_from_ordered_ids(shuffled_player_ids)
+
+
+class SmartSeedPlacementStrategy(PlacementStrategy):
+    RANK_FIELDS = ("rank_total", "rank_lastyear", "rank_group")
+
+    def __init__(self, rng=None, max_seed=8):
+        self.rng = rng or random.Random()
+        self.max_seed = max_seed
+
+    def build_slot_players(self, players):
+        placement_players = [placement_player_from_entry(player) for player in players]
+        slots = build_slots(len(placement_players))
+        apply_byes(slots, len(placement_players))
+
+        seeded_players = self.seeded_players(placement_players)
+        seed_to_slot = {slot.seed: slot for slot in slots}
+        seeded_player_ids = set()
+
+        for seed, player in enumerate(seeded_players, start=1):
+            if seed > self.max_seed or seed not in seed_to_slot:
+                break
+            seed_to_slot[seed].player_id = player.player_id
+            seeded_player_ids.add(player.player_id)
+
+        remaining_player_ids = [
+            player.player_id
+            for player in placement_players
+            if player.player_id not in seeded_player_ids
+        ]
+        self.rng.shuffle(remaining_player_ids)
+        assign_players_to_open_slots(slots, remaining_player_ids)
+        return slot_player_ids(slots)
+
+    def seeded_players(self, players):
+        seeded_players = []
+        seeded_player_ids = set()
+        for rank_field in self.RANK_FIELDS:
+            ranked_players = [
+                player
+                for player in players
+                if player.player_id not in seeded_player_ids
+                and rank_value(getattr(player, rank_field)) is not None
+            ]
+            self.rng.shuffle(ranked_players)
+            for player in sorted(
+                ranked_players,
+                key=lambda player: rank_value(getattr(player, rank_field)),
+            ):
+                seeded_players.append(player)
+                seeded_player_ids.add(player.player_id)
+                if len(seeded_players) >= self.max_seed:
+                    return seeded_players
+        return seeded_players
+
+
+def player_id_from_entry(player):
+    if isinstance(player, PlacementPlayer):
+        return player.player_id
+    if isinstance(player, dict):
+        return player["player_id"]
+    return str(player)
+
+
+def placement_player_from_entry(player):
+    if isinstance(player, PlacementPlayer):
+        return player
+    if isinstance(player, dict):
+        return PlacementPlayer(
+            player_id=str(player["player_id"]),
+            rank_group=str(player.get("rank_group", "")),
+            rank_lastyear=str(player.get("rank_lastyear", "")),
+            rank_total=str(player.get("rank_total", "")),
+        )
+    return PlacementPlayer(player_id=str(player))
+
+
+def rank_value(value):
+    value = str(value).strip()
+    return int(value) if value.isdigit() else None
 
 
 def build_slot_players(player_ids, strategy=None):


### PR DESCRIPTION
トーナメント自動生成で、各種ランク情報を考慮しシード位置を設定するようにします

total(手動入力の全体ランク) > lastyear (昨年度実績) > group(団体内) の優先度で、シード1から8まで順に埋めます