### PR TITLE
consider group/rank balance in tournament generation

### DIFF
--- a/components/tournament_editor.js
+++ b/components/tournament_editor.js
@@ -13,7 +13,6 @@ import {
   Checkbox,
   Container,
   Divider,
-  FormControlLabel,
   Grid,
   MenuItem,
   Paper,
@@ -147,13 +146,8 @@ function enrichRows(rows, playerMap) {
   });
 }
 
-function getGroupColor(
-  groupName,
-  groupColorMap,
-  colorByGroup,
-  highlightedGroupName,
-) {
-  if (!colorByGroup || !groupName) {
+function getGroupColor(groupName, groupColorMap, highlightedGroupName) {
+  if (!groupName) {
     return null;
   }
   if (
@@ -234,7 +228,6 @@ function PlayerText({
   selectedSlot,
   onSelectSlot,
   groupColorMap,
-  colorByGroup,
   highlightedGroupName,
   showPlayerIds,
   auxiliaryMode,
@@ -253,12 +246,7 @@ function PlayerText({
     selectedSlot &&
     selectedSlot.original_id === item.original_id &&
     selectedSlot.side === side;
-  const fill = getGroupColor(
-    groupName,
-    groupColorMap,
-    colorByGroup,
-    highlightedGroupName,
-  );
+  const fill = getGroupColor(groupName, groupColorMap, highlightedGroupName);
   const textY = y + yPadding;
 
   return (
@@ -513,7 +501,6 @@ function GameShape({
 
 function TournamentCanvas({
   rows,
-  colorByGroup,
   highlightedGroupName,
   auxiliaryMode,
   printMode,
@@ -591,8 +578,9 @@ function TournamentCanvas({
                       selectedSlot={selectedSlot}
                       onSelectSlot={onSelectSlot}
                       groupColorMap={groupColorMap}
-                      colorByGroup={colorByGroup && !printMode}
-                      highlightedGroupName={highlightedGroupName}
+                      highlightedGroupName={
+                        printMode ? [] : highlightedGroupName
+                      }
                       showPlayerIds={!printMode}
                       auxiliaryMode={printMode ? "none" : auxiliaryMode}
                     />
@@ -607,8 +595,9 @@ function TournamentCanvas({
                       selectedSlot={selectedSlot}
                       onSelectSlot={onSelectSlot}
                       groupColorMap={groupColorMap}
-                      colorByGroup={colorByGroup && !printMode}
-                      highlightedGroupName={highlightedGroupName}
+                      highlightedGroupName={
+                        printMode ? [] : highlightedGroupName
+                      }
                       showPlayerIds={!printMode}
                       auxiliaryMode={printMode ? "none" : auxiliaryMode}
                     />
@@ -746,7 +735,6 @@ export default function TournamentEditor({ competition, eventName }) {
   });
   const [selectedSlot, setSelectedSlot] = useState(null);
   const [selectedGameId, setSelectedGameId] = useState(null);
-  const [colorByGroup, setColorByGroup] = useState(false);
   const [highlightedGroupName, setHighlightedGroupName] = useState([]);
   const [auxiliaryMode, setAuxiliaryMode] = useState("none");
   const [printMode, setPrintMode] = useState(false);
@@ -981,7 +969,6 @@ export default function TournamentEditor({ competition, eventName }) {
             ) : (
               <TournamentCanvas
                 rows={layoutRows}
-                colorByGroup={colorByGroup}
                 highlightedGroupName={highlightedGroupName}
                 auxiliaryMode={auxiliaryMode}
                 printMode={printMode}
@@ -1002,18 +989,8 @@ export default function TournamentEditor({ competition, eventName }) {
                   選手名または試合番号をクリックして編集します。
                 </Typography>
               </Box>
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={colorByGroup}
-                    onChange={(event) => setColorByGroup(event.target.checked)}
-                  />
-                }
-                label="所属色を表示"
-              />
               <TextField
                 select
-                label="所属色の対象"
                 value={highlightedGroupName}
                 onChange={(event) => {
                   const value = event.target.value;
@@ -1032,12 +1009,11 @@ export default function TournamentEditor({ competition, eventName }) {
                 }}
                 fullWidth
                 size="small"
-                disabled={!colorByGroup}
                 SelectProps={{
                   multiple: true,
                   displayEmpty: true,
                   renderValue: (selected) =>
-                    selected.length === 0 ? "なし" : selected.join(", "),
+                    selected.length === 0 ? "所属色なし" : selected.join(", "),
                 }}
               >
                 <MenuItem value={ALL_GROUPS_VALUE}>

--- a/scripts/generate_tournament_csv.py
+++ b/scripts/generate_tournament_csv.py
@@ -320,6 +320,7 @@ def generate_from_source_csvs(args):
                 seed=args.seed,
                 max_attempts=args.placement_attempts,
                 max_search_nodes=args.placement_search_nodes,
+                progress_label=event_name,
             )
         )
         try:
@@ -382,13 +383,13 @@ def parse_args():
     parser.add_argument(
         "--placement-attempts",
         type=int,
-        default=100,
+        default=20,
         help="max smart placement attempts with derived random seeds",
     )
     parser.add_argument(
         "--placement-search-nodes",
         type=int,
-        default=1000,
+        default=2000,
         help="max backtracking nodes per smart placement attempt",
     )
     return parser.parse_args()

--- a/scripts/generate_tournament_csv.py
+++ b/scripts/generate_tournament_csv.py
@@ -282,7 +282,12 @@ def placement_players_from_rows(rows, event_name):
 def create_placement_strategy(args, rng):
     if args.placement == "random":
         return RandomPlacementStrategy(rng)
-    return SmartSeedPlacementStrategy(rng)
+    return SmartSeedPlacementStrategy(
+        rng,
+        seed=args.seed,
+        max_attempts=args.placement_attempts,
+        max_search_nodes=args.placement_search_nodes,
+    )
 
 
 def generate_from_source_csvs(args):
@@ -310,7 +315,12 @@ def generate_from_source_csvs(args):
         placement_strategy = (
             random_placement_strategy
             if args.placement == "random"
-            else SmartSeedPlacementStrategy(random.Random(args.seed))
+            else SmartSeedPlacementStrategy(
+                random.Random(args.seed),
+                seed=args.seed,
+                max_attempts=args.placement_attempts,
+                max_search_nodes=args.placement_search_nodes,
+            )
         )
         try:
             slot_players = placement_strategy.build_slot_players(players)
@@ -369,6 +379,18 @@ def parse_args():
         help="player placement strategy (default: smart)",
     )
     parser.add_argument("--seed", type=int, help="random seed for reproducible shuffling")
+    parser.add_argument(
+        "--placement-attempts",
+        type=int,
+        default=100,
+        help="max smart placement attempts with derived random seeds",
+    )
+    parser.add_argument(
+        "--placement-search-nodes",
+        type=int,
+        default=1000,
+        help="max backtracking nodes per smart placement attempt",
+    )
     return parser.parse_args()
 
 

--- a/scripts/generate_tournament_csv.py
+++ b/scripts/generate_tournament_csv.py
@@ -269,6 +269,7 @@ def placement_players_from_rows(rows, event_name):
     return [
         {
             "player_id": clean_player_id(row.get(player_column, "")),
+            "group_id": clean_integer(row.get("group_id", "")),
             "rank_group": clean_integer(row.get(f"{event_name}_rank_group", "")),
             "rank_lastyear": clean_integer(row.get(f"{event_name}_rank_lastyear", "")),
             "rank_total": clean_integer(row.get(f"{event_name}_rank_total", "")),
@@ -298,7 +299,7 @@ def generate_from_source_csvs(args):
     print(f"wrote {static_sql}")
 
     rng = random.Random(args.seed)
-    placement_strategy = create_placement_strategy(args, rng)
+    random_placement_strategy = RandomPlacementStrategy(rng)
     generated_event_names = []
     for event_name in event_names:
         players = placement_players_from_rows(output_rows, event_name)
@@ -306,7 +307,15 @@ def generate_from_source_csvs(args):
             print(f"skipped {event_name} ({len(players)} players)", file=sys.stderr)
             continue
 
-        slot_players = placement_strategy.build_slot_players(players)
+        placement_strategy = (
+            random_placement_strategy
+            if args.placement == "random"
+            else SmartSeedPlacementStrategy(random.Random(args.seed))
+        )
+        try:
+            slot_players = placement_strategy.build_slot_players(players)
+        except ValueError as e:
+            raise ValueError(f"{event_name}: {e}") from e
         games = build_games_from_slots(slot_players)
         output_csv = Path("data") / args.competition / "original" / f"{event_name}.csv"
 

--- a/scripts/tournament_player_placement.py
+++ b/scripts/tournament_player_placement.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from dataclasses import replace
 import random
 
 
@@ -7,6 +8,9 @@ class TournamentSlot:
     index: int
     seed: int
     opponent_index: int
+    visual_half: str
+    visual_vertical: str
+    visual_quarter: str
     player_id: str = ""
     occupied: bool = True
 
@@ -14,6 +18,7 @@ class TournamentSlot:
 @dataclass
 class PlacementPlayer:
     player_id: str
+    group_id: str = ""
     rank_group: str = ""
     rank_lastyear: str = ""
     rank_total: str = ""
@@ -56,9 +61,31 @@ def build_slots(player_count):
             index=index,
             seed=seed,
             opponent_index=index + 1 if index % 2 == 0 else index - 1,
+            visual_half=visual_half_for_index(index, slot_count),
+            visual_vertical=visual_vertical_for_index(index, slot_count),
+            visual_quarter=visual_quarter_for_index(index, slot_count),
         )
         for index, seed in enumerate(seeds)
     ]
+
+
+def visual_quarter_for_index(index, slot_count):
+    quarter = index * 4 // slot_count
+    if quarter == 0:
+        return "left_top"
+    if quarter == 1:
+        return "left_bottom"
+    if quarter == 2:
+        return "right_bottom"
+    return "right_top"
+
+
+def visual_half_for_index(index, slot_count):
+    return "left" if visual_quarter_for_index(index, slot_count).startswith("left_") else "right"
+
+
+def visual_vertical_for_index(index, slot_count):
+    return "top" if visual_quarter_for_index(index, slot_count).endswith("_top") else "bottom"
 
 
 def apply_byes(slots, player_count):
@@ -122,6 +149,11 @@ class SmartSeedPlacementStrategy(PlacementStrategy):
         apply_byes(slots, len(placement_players))
 
         seeded_players = self.seeded_players(placement_players)
+        seeded_players = self.reorder_tied_seed_players(
+            slots,
+            placement_players,
+            seeded_players,
+        )
         seed_to_slot = {slot.seed: slot for slot in slots}
         seeded_player_ids = set()
 
@@ -131,13 +163,12 @@ class SmartSeedPlacementStrategy(PlacementStrategy):
             seed_to_slot[seed].player_id = player.player_id
             seeded_player_ids.add(player.player_id)
 
-        remaining_player_ids = [
-            player.player_id
+        remaining_players = [
+            player
             for player in placement_players
             if player.player_id not in seeded_player_ids
         ]
-        self.rng.shuffle(remaining_player_ids)
-        assign_players_to_open_slots(slots, remaining_player_ids)
+        self.place_remaining_players(slots, placement_players, remaining_players)
         return slot_player_ids(slots)
 
     def seeded_players(self, players):
@@ -161,6 +192,350 @@ class SmartSeedPlacementStrategy(PlacementStrategy):
                     return seeded_players
         return seeded_players
 
+    def reorder_tied_seed_players(self, slots, all_players, seeded_players):
+        if len(seeded_players) <= 1:
+            return seeded_players
+
+        reordered_players = []
+        seed_to_slot = {slot.seed: slot for slot in slots}
+        player_by_id = {player.player_id: player for player in all_players}
+        fixed_seeded_players = []
+        start = 0
+
+        while start < len(seeded_players):
+            end = start + 1
+            seed_key = self.seed_priority_key(seeded_players[start])
+            while end < len(seeded_players) and self.seed_priority_key(seeded_players[end]) == seed_key:
+                end += 1
+
+            group_players = seeded_players[start:end]
+            seed_numbers = list(range(start + 1, end + 1))
+            reordered_group = self.best_seed_order_for_tied_players(
+                slots,
+                seed_to_slot,
+                player_by_id,
+                all_players,
+                fixed_seeded_players,
+                group_players,
+                seed_numbers,
+                seeded_players[end:],
+                end + 1,
+            )
+            reordered_players.extend(reordered_group)
+            fixed_seeded_players.extend(reordered_group)
+            start = end
+
+        return reordered_players
+
+    def seed_priority_key(self, player):
+        for rank_index, rank_field in enumerate(self.RANK_FIELDS):
+            value = rank_value(getattr(player, rank_field))
+            if value is not None:
+                return (rank_index, value)
+        return (len(self.RANK_FIELDS), self.max_seed + 1)
+
+    def best_seed_order_for_tied_players(
+        self,
+        slots,
+        seed_to_slot,
+        player_by_id,
+        all_players,
+        fixed_seeded_players,
+        group_players,
+        seed_numbers,
+        future_seeded_players,
+        future_start_seed,
+    ):
+        if len(group_players) <= 1:
+            return group_players
+
+        fixed_seeded_ids = {player.player_id for player in fixed_seeded_players}
+        group_seeded_ids = {player.player_id for player in group_players}
+        future_seeded_ids = {player.player_id for player in future_seeded_players}
+        remaining_players = [
+            player
+            for player in all_players
+            if player.player_id not in fixed_seeded_ids
+            and player.player_id not in group_seeded_ids
+            and player.player_id not in future_seeded_ids
+        ]
+
+        ordered_players = []
+        unordered_players = list(group_players)
+        for current_index, seed in enumerate(seed_numbers):
+            best_player = None
+            best_score = None
+            for player in unordered_players:
+                trial_order = ordered_players + [player] + [
+                    candidate
+                    for candidate in unordered_players
+                    if candidate.player_id != player.player_id
+                ]
+                score = self.seed_order_score(
+                    slots,
+                    player_by_id,
+                    fixed_seeded_players,
+                    trial_order,
+                    seed_numbers,
+                    future_seeded_players,
+                    future_start_seed,
+                    remaining_players,
+                )
+                if best_score is None or score < best_score:
+                    best_score = score
+                    best_player = player
+            ordered_players.append(best_player)
+            unordered_players = [
+                player
+                for player in unordered_players
+                if player.player_id != best_player.player_id
+            ]
+
+        return ordered_players
+
+    def seed_order_score(
+        self,
+        slots,
+        player_by_id,
+        fixed_seeded_players,
+        group_players,
+        seed_numbers,
+        future_seeded_players,
+        future_start_seed,
+        remaining_players,
+    ):
+        trial_slots = [replace(slot) for slot in slots]
+        trial_by_seed = {slot.seed: slot for slot in trial_slots}
+        for seed, player in enumerate(fixed_seeded_players, start=1):
+            if seed in trial_by_seed:
+                trial_by_seed[seed].player_id = player.player_id
+        for seed, player in zip(seed_numbers, group_players):
+            if seed in trial_by_seed:
+                trial_by_seed[seed].player_id = player.player_id
+        for seed, player in enumerate(future_seeded_players, start=future_start_seed):
+            if seed in trial_by_seed:
+                trial_by_seed[seed].player_id = player.player_id
+
+        # Tied seed candidates have equal rank priority. Choose the order
+        # that leaves the most legal slots for non-seeded teammates.
+        candidate_counts = [
+            len(self.hard_constraint_slots(trial_slots, player_by_id, player))
+            for player in remaining_players
+        ]
+        unmatched_count = self.unmatched_player_count(
+            trial_slots,
+            player_by_id,
+            remaining_players,
+        )
+        zero_count = sum(1 for count in candidate_counts if count == 0)
+        total_count = sum(candidate_counts)
+        return (unmatched_count, zero_count, -total_count)
+
+    def unmatched_player_count(self, slots, player_by_id, players):
+        slot_indexes = [
+            slot.index
+            for slot in slots
+            if slot.occupied and not slot.player_id
+        ]
+        edges = {
+            player.player_id: [
+                slot.index
+                for slot in self.hard_constraint_slots(slots, player_by_id, player)
+            ]
+            for player in players
+        }
+        matched_players = self.maximum_bipartite_matching_size(
+            [player.player_id for player in players],
+            slot_indexes,
+            edges,
+        )
+        return len(players) - matched_players
+
+    def maximum_bipartite_matching_size(self, player_ids, slot_indexes, edges):
+        matched_player_by_slot = {}
+
+        def assign(player_id, seen_slots):
+            for slot_index in edges[player_id]:
+                if slot_index in seen_slots:
+                    continue
+                seen_slots.add(slot_index)
+                if slot_index not in matched_player_by_slot or assign(
+                    matched_player_by_slot[slot_index],
+                    seen_slots,
+                ):
+                    matched_player_by_slot[slot_index] = player_id
+                    return True
+            return False
+
+        return sum(
+            1
+            for player_id in player_ids
+            if assign(player_id, set())
+        )
+
+    def place_remaining_players(self, slots, all_players, remaining_players):
+        player_by_id = {player.player_id: player for player in all_players}
+        self.rng.shuffle(remaining_players)
+
+        solved_slots = self.solve_players_backtracking(slots, player_by_id, list(remaining_players))
+        if not solved_slots:
+            raise ValueError("could not place remaining players without breaking group constraints")
+        for index, solved_slot in enumerate(solved_slots):
+            slots[index].player_id = solved_slot.player_id
+
+    def solve_players_backtracking(self, slots, player_by_id, remaining_players):
+        if not remaining_players:
+            return slots
+
+        player = min(
+            remaining_players,
+            key=lambda player: (
+                self.remaining_priority(slots, player_by_id, player),
+                len(self.hard_constraint_slots(slots, player_by_id, player)),
+                self.rng.random(),
+            ),
+        )
+        candidate_slots = self.hard_constraint_slots(slots, player_by_id, player)
+        if not candidate_slots:
+            return None
+
+        self.rng.shuffle(candidate_slots)
+        candidate_slots = sorted(
+            candidate_slots,
+            key=lambda slot: (
+                self.balance_score(slots, player_by_id, player, slot),
+            ),
+        )
+
+        next_remaining_players = [
+            remaining_player
+            for remaining_player in remaining_players
+            if remaining_player.player_id != player.player_id
+        ]
+        for slot in candidate_slots:
+            trial_slots = [replace(candidate) for candidate in slots]
+            trial_slots[slot.index].player_id = player.player_id
+            solved_slots = self.solve_players_backtracking(
+                trial_slots,
+                player_by_id,
+                next_remaining_players,
+            )
+            if solved_slots:
+                return solved_slots
+        return None
+
+    def future_constraint_score(self, slots, player_by_id, remaining_players, player, slot):
+        trial_slots = [replace(candidate) for candidate in slots]
+        trial_slots[slot.index].player_id = player.player_id
+        candidate_counts = [
+            len(self.hard_constraint_slots(trial_slots, player_by_id, remaining_player))
+            for remaining_player in remaining_players
+            if remaining_player.player_id != player.player_id
+        ]
+        zero_count = sum(1 for count in candidate_counts if count == 0)
+        return (zero_count, -sum(candidate_counts))
+
+    def remaining_priority(self, slots, player_by_id, player):
+        # Place constrained players first. This keeps later random fill from
+        # consuming the few slots that satisfy recommendation/group-rank rules.
+        return (
+            0 if self.lastyear_group_restriction(slots, player_by_id, player) else 1,
+            0 if rank_value(player.rank_group) in (1, 2) else 1,
+        )
+
+    def hard_constraint_slots(self, slots, player_by_id, player):
+        candidate_slots = [
+            slot
+            for slot in slots
+            if slot.occupied and not slot.player_id
+        ]
+        restriction = self.lastyear_group_restriction(slots, player_by_id, player)
+        if restriction:
+            kind, value = restriction
+            candidate_slots = [
+                slot
+                for slot in candidate_slots
+                if getattr(slot, kind) == value
+            ]
+
+        opposing_half = self.opposing_rank_group_half(slots, player_by_id, player)
+        if opposing_half:
+            candidate_slots = [
+                slot
+                for slot in candidate_slots
+                if slot.visual_half != opposing_half
+            ]
+        return candidate_slots
+
+    def lastyear_group_restriction(self, slots, player_by_id, player):
+        if not player.group_id or rank_value(player.rank_lastyear) is not None:
+            return None
+
+        lastyear_slots = [
+            slot
+            for slot in slots
+            if slot.player_id
+            and player_by_id[slot.player_id].group_id == player.group_id
+            and rank_value(player_by_id[slot.player_id].rank_lastyear) is not None
+        ]
+        if not lastyear_slots:
+            return None
+
+        halves = {slot.visual_half for slot in lastyear_slots}
+        verticals = {slot.visual_vertical for slot in lastyear_slots}
+
+        # If a group has recommendation seeds on one side only, non-recommendation
+        # teammates must go to the opposite side. If recommendation seeds already
+        # exist on both sides, avoid their occupied top/bottom side when possible.
+        if halves == {"left"}:
+            return ("visual_half", "right")
+        if halves == {"right"}:
+            return ("visual_half", "left")
+        if len(halves) > 1 and verticals == {"top"}:
+            return ("visual_vertical", "bottom")
+        if len(halves) > 1 and verticals == {"bottom"}:
+            return ("visual_vertical", "top")
+        return None
+
+    def opposing_rank_group_half(self, slots, player_by_id, player):
+        if not player.group_id:
+            return None
+
+        rank_group = rank_value(player.rank_group)
+        if rank_group not in (1, 2):
+            return None
+        opposing_rank = 2 if rank_group == 1 else 1
+
+        opposing_halves = {
+            slot.visual_half
+            for slot in slots
+            if slot.player_id
+            and player_by_id[slot.player_id].group_id == player.group_id
+            and rank_value(player_by_id[slot.player_id].rank_group) == opposing_rank
+        }
+        if len(opposing_halves) == 1:
+            return next(iter(opposing_halves))
+        return None
+
+    def balance_score(self, slots, player_by_id, player, slot):
+        rank_group = rank_value(player.rank_group)
+        if rank_group not in (1, 2):
+            return 0
+
+        same_rank_slots = [
+            placed_slot
+            for placed_slot in slots
+            if placed_slot.player_id
+            and rank_value(player_by_id[placed_slot.player_id].rank_group) == rank_group
+        ]
+        half_count = sum(
+            1 for placed_slot in same_rank_slots if placed_slot.visual_half == slot.visual_half
+        )
+        vertical_count = sum(
+            1 for placed_slot in same_rank_slots if placed_slot.visual_vertical == slot.visual_vertical
+        )
+        return half_count + vertical_count
+
 
 def player_id_from_entry(player):
     if isinstance(player, PlacementPlayer):
@@ -176,6 +551,7 @@ def placement_player_from_entry(player):
     if isinstance(player, dict):
         return PlacementPlayer(
             player_id=str(player["player_id"]),
+            group_id=str(player.get("group_id", "")),
             rank_group=str(player.get("rank_group", "")),
             rank_lastyear=str(player.get("rank_lastyear", "")),
             rank_total=str(player.get("rank_total", "")),

--- a/scripts/tournament_player_placement.py
+++ b/scripts/tournament_player_placement.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import replace
 import random
+import sys
 
 
 @dataclass
@@ -142,6 +143,12 @@ class RandomPlacementStrategy(PlacementStrategy):
 
 class SmartSeedPlacementStrategy(PlacementStrategy):
     RANK_FIELDS = ("rank_total", "rank_lastyear", "rank_group")
+    RELAX_ORDER = (
+        "same_rank_first_round",
+        "same_group_rank_1_4_quarter",
+        "same_group_quarter",
+        "same_group_first_round",
+    )
 
     def __init__(
         self,
@@ -150,28 +157,42 @@ class SmartSeedPlacementStrategy(PlacementStrategy):
         seed=None,
         max_attempts=100,
         max_search_nodes=1000,
+        progress_label="",
     ):
         self.rng = rng or random.Random()
         self.max_seed = max_seed
         self.seed = seed
         self.max_attempts = max_attempts
         self.max_search_nodes = max_search_nodes
+        self.progress_label = progress_label
         self.search_nodes = 0
+        self.relaxed_constraints = set()
 
     def build_slot_players(self, players):
         last_error = None
-        for attempt in range(self.max_attempts):
-            if self.seed is None:
-                self.rng = random.Random(self.rng.random())
-            else:
-                self.rng = random.Random(self.seed + attempt)
-            self.search_nodes = 0
-            try:
-                return self.build_slot_players_once(players)
-            except ValueError as e:
-                last_error = e
+        relax_steps = range(len(self.RELAX_ORDER) + 1)
+        attempts_per_step = max(1, self.max_attempts // len(list(relax_steps)))
+        for relax_count in relax_steps:
+            self.relaxed_constraints = set(self.RELAX_ORDER[:relax_count])
+            for attempt in range(attempts_per_step):
+                if self.progress_label:
+                    relaxed = ",".join(self.RELAX_ORDER[:relax_count]) or "none"
+                    print(
+                        f"placing {self.progress_label}: relaxed={relaxed} "
+                        f"attempt={attempt + 1}/{attempts_per_step}",
+                        file=sys.stderr,
+                    )
+                if self.seed is None:
+                    self.rng = random.Random(self.rng.random())
+                else:
+                    self.rng = random.Random(self.seed + relax_count * attempts_per_step + attempt)
+                self.search_nodes = 0
+                try:
+                    return self.build_slot_players_once(players)
+                except ValueError as e:
+                    last_error = e
         raise ValueError(
-            f"could not place players after {self.max_attempts} attempts"
+            f"could not place players after {attempts_per_step} attempts at each relax step"
         ) from last_error
 
     def build_slot_players_once(self, players):
@@ -502,12 +523,34 @@ class SmartSeedPlacementStrategy(PlacementStrategy):
                 for slot in candidate_slots
                 if slot.visual_half != opposing_half
             ]
-        candidate_slots = [
-            slot
-            for slot in candidate_slots
-            if not self.has_same_group_first_round_opponent(slots, player_by_id, player, slot)
-        ]
+        if self.is_hard("same_group_first_round"):
+            candidate_slots = [
+                slot
+                for slot in candidate_slots
+                if not self.has_same_group_first_round_opponent(slots, player_by_id, player, slot)
+            ]
+        if self.is_hard("same_group_quarter"):
+            candidate_slots = [
+                slot
+                for slot in candidate_slots
+                if not self.has_same_group_quarter_conflict(slots, player_by_id, player, slot)
+            ]
+        if self.is_hard("same_group_rank_1_4_quarter"):
+            candidate_slots = [
+                slot
+                for slot in candidate_slots
+                if not self.has_same_group_rank_quarter_conflict(slots, player_by_id, player, slot)
+            ]
+        if self.is_hard("same_rank_first_round"):
+            candidate_slots = [
+                slot
+                for slot in candidate_slots
+                if not self.has_same_rank_first_round_opponent(slots, player_by_id, player, slot)
+            ]
         return candidate_slots
+
+    def is_hard(self, constraint_name):
+        return constraint_name in self.RELAX_ORDER and constraint_name not in self.relaxed_constraints
 
     def has_same_group_first_round_opponent(self, slots, player_by_id, player, slot):
         if not player.group_id:
@@ -517,6 +560,37 @@ class SmartSeedPlacementStrategy(PlacementStrategy):
         return (
             bool(opponent_player_id)
             and player_by_id[opponent_player_id].group_id == player.group_id
+        )
+
+    def has_same_group_quarter_conflict(self, slots, player_by_id, player, slot):
+        if not player.group_id:
+            return False
+        return any(
+            placed_slot.player_id
+            and player_by_id[placed_slot.player_id].group_id == player.group_id
+            and placed_slot.visual_quarter == slot.visual_quarter
+            for placed_slot in slots
+        )
+
+    def has_same_group_rank_quarter_conflict(self, slots, player_by_id, player, slot):
+        if not player.group_id or rank_value(player.rank_group) not in (1, 2, 3, 4):
+            return False
+        return any(
+            placed_slot.player_id
+            and player_by_id[placed_slot.player_id].group_id == player.group_id
+            and rank_value(player_by_id[placed_slot.player_id].rank_group) in (1, 2, 3, 4)
+            and placed_slot.visual_quarter == slot.visual_quarter
+            for placed_slot in slots
+        )
+
+    def has_same_rank_first_round_opponent(self, slots, player_by_id, player, slot):
+        rank_group = rank_value(player.rank_group)
+        if rank_group is None:
+            return False
+        opponent_player_id = slots[slot.opponent_index].player_id
+        return (
+            bool(opponent_player_id)
+            and rank_value(player_by_id[opponent_player_id].rank_group) == rank_group
         )
 
     def lastyear_group_restriction(self, slots, player_by_id, player):
@@ -596,8 +670,16 @@ class SmartSeedPlacementStrategy(PlacementStrategy):
                 for placed_slot in same_group_slots
                 if placed_slot.visual_vertical == slot.visual_vertical
             )
+            if self.has_same_group_first_round_opponent(slots, player_by_id, player, slot):
+                group_score += 100
+            if self.has_same_group_quarter_conflict(slots, player_by_id, player, slot):
+                group_score += 40
+            if self.has_same_group_rank_quarter_conflict(slots, player_by_id, player, slot):
+                group_score += 30
 
         rank_group = rank_value(player.rank_group)
+        if self.has_same_rank_first_round_opponent(slots, player_by_id, player, slot):
+            group_score += 20
         if rank_group not in (1, 2):
             return group_score
 

--- a/scripts/tournament_player_placement.py
+++ b/scripts/tournament_player_placement.py
@@ -29,6 +29,10 @@ class PlacementStrategy:
         raise NotImplementedError
 
 
+class PlacementSearchLimitExceeded(ValueError):
+    pass
+
+
 def next_power_of_two(value):
     return 1 << (value - 1).bit_length()
 
@@ -139,11 +143,38 @@ class RandomPlacementStrategy(PlacementStrategy):
 class SmartSeedPlacementStrategy(PlacementStrategy):
     RANK_FIELDS = ("rank_total", "rank_lastyear", "rank_group")
 
-    def __init__(self, rng=None, max_seed=8):
+    def __init__(
+        self,
+        rng=None,
+        max_seed=8,
+        seed=None,
+        max_attempts=100,
+        max_search_nodes=1000,
+    ):
         self.rng = rng or random.Random()
         self.max_seed = max_seed
+        self.seed = seed
+        self.max_attempts = max_attempts
+        self.max_search_nodes = max_search_nodes
+        self.search_nodes = 0
 
     def build_slot_players(self, players):
+        last_error = None
+        for attempt in range(self.max_attempts):
+            if self.seed is None:
+                self.rng = random.Random(self.rng.random())
+            else:
+                self.rng = random.Random(self.seed + attempt)
+            self.search_nodes = 0
+            try:
+                return self.build_slot_players_once(players)
+            except ValueError as e:
+                last_error = e
+        raise ValueError(
+            f"could not place players after {self.max_attempts} attempts"
+        ) from last_error
+
+    def build_slot_players_once(self, players):
         placement_players = [placement_player_from_entry(player) for player in players]
         slots = build_slots(len(placement_players))
         apply_byes(slots, len(placement_players))
@@ -384,6 +415,12 @@ class SmartSeedPlacementStrategy(PlacementStrategy):
             slots[index].player_id = solved_slot.player_id
 
     def solve_players_backtracking(self, slots, player_by_id, remaining_players):
+        self.search_nodes += 1
+        if self.search_nodes > self.max_search_nodes:
+            raise PlacementSearchLimitExceeded(
+                f"placement search exceeded {self.max_search_nodes} nodes"
+            )
+
         if not remaining_players:
             return slots
 
@@ -465,7 +502,22 @@ class SmartSeedPlacementStrategy(PlacementStrategy):
                 for slot in candidate_slots
                 if slot.visual_half != opposing_half
             ]
+        candidate_slots = [
+            slot
+            for slot in candidate_slots
+            if not self.has_same_group_first_round_opponent(slots, player_by_id, player, slot)
+        ]
         return candidate_slots
+
+    def has_same_group_first_round_opponent(self, slots, player_by_id, player, slot):
+        if not player.group_id:
+            return False
+
+        opponent_player_id = slots[slot.opponent_index].player_id
+        return (
+            bool(opponent_player_id)
+            and player_by_id[opponent_player_id].group_id == player.group_id
+        )
 
     def lastyear_group_restriction(self, slots, player_by_id, player):
         if not player.group_id or rank_value(player.rank_lastyear) is not None:
@@ -518,9 +570,36 @@ class SmartSeedPlacementStrategy(PlacementStrategy):
         return None
 
     def balance_score(self, slots, player_by_id, player, slot):
+        group_score = 0
+        if player.group_id:
+            same_group_slots = [
+                placed_slot
+                for placed_slot in slots
+                if placed_slot.player_id
+                and player_by_id[placed_slot.player_id].group_id == player.group_id
+            ]
+            # Same-group first-round matches are filtered as a hard constraint.
+            # Beyond that, keep teammates out of the same visual quarter first,
+            # then prefer spreading them across left/right and top/bottom.
+            group_score += 8 * sum(
+                1
+                for placed_slot in same_group_slots
+                if placed_slot.visual_quarter == slot.visual_quarter
+            )
+            group_score += 2 * sum(
+                1
+                for placed_slot in same_group_slots
+                if placed_slot.visual_half == slot.visual_half
+            )
+            group_score += sum(
+                1
+                for placed_slot in same_group_slots
+                if placed_slot.visual_vertical == slot.visual_vertical
+            )
+
         rank_group = rank_value(player.rank_group)
         if rank_group not in (1, 2):
-            return 0
+            return group_score
 
         same_rank_slots = [
             placed_slot
@@ -534,7 +613,7 @@ class SmartSeedPlacementStrategy(PlacementStrategy):
         vertical_count = sum(
             1 for placed_slot in same_rank_slots if placed_slot.visual_vertical == slot.visual_vertical
         )
-        return half_count + vertical_count
+        return group_score + half_count + vertical_count
 
 
 def player_id_from_entry(player):


### PR DESCRIPTION
所属団体をなるべくバラけさせる、団体内順位のバランスなどを考慮しながらトーナメントの選手配置を生成できるようにします
なるべく最初は制約条件強めで、満たせなさそうなら徐々に緩めていくような実装にしています

ついでに、所属団体色分け表示のところで冗長なUIコンポーネントを削除しました