### PR TITLE
add operation unlock button

### DIFF
--- a/components/block.js
+++ b/components/block.js
@@ -36,8 +36,9 @@ function ShowDetails(
           type="submit"
           onClick={(e) => ToCall(block_number, item["id"], item["event_id"])}
           disabled={
-            item["id"] !== current.id ||
-            (!operation_unlock && !item["players_checked"])
+            item["id"] < current.id ||
+            (!operation_unlock &&
+              (item["id"] !== current.id || !item["players_checked"]))
           }
           sx={{ width: "5rem", marginBottom: "5px" }}
         >
@@ -104,8 +105,9 @@ function ShowDetails(
         type="submit"
         onClick={(e) => ToCall(block_number, item["id"], item["event_id"])}
         disabled={
-          item["id"] !== current.id ||
-          (!operation_unlock && !item["players_checked"])
+          item["id"] < current.id ||
+          (!operation_unlock &&
+            (item["id"] !== current.id || !item["players_checked"]))
         }
       >
         呼び出し

--- a/components/block.js
+++ b/components/block.js
@@ -25,6 +25,7 @@ function ShowDetails(
   ToRecord,
   ToUpdate,
   ToFinish,
+  operation_unlock,
 ) {
   if (is_mobile) {
     return (
@@ -34,7 +35,10 @@ function ShowDetails(
           variant="contained"
           type="submit"
           onClick={(e) => ToCall(block_number, item["id"], item["event_id"])}
-          disabled={item["id"] !== current.id || !item["players_checked"]}
+          disabled={
+            item["id"] !== current.id ||
+            (!operation_unlock && !item["players_checked"])
+          }
           sx={{ width: "5rem", marginBottom: "5px" }}
         >
           呼び出し
@@ -48,11 +52,29 @@ function ShowDetails(
               onClick={(e) =>
                 ToRecord(block_number, item["id"], item["event_id"])
               }
-              disabled={item["id"] !== current.id || !item["players_checked"]}
+              disabled={
+                item["id"] !== current.id ||
+                (!operation_unlock && !item["players_checked"])
+              }
               sx={{ width: "5rem", marginBottom: "5px" }}
             >
               記録　
             </Button>
+            {operation_unlock ? (
+              <>
+                <br />
+                <Button
+                  variant="contained"
+                  type="submit"
+                  onClick={(e) =>
+                    ToUpdate(block_number, item["id"], item["event_id"])
+                  }
+                  sx={{ width: "5rem", marginBottom: "5px" }}
+                >
+                  結果修正
+                </Button>
+              </>
+            ) : null}
           </>
         ) : (
           <>
@@ -62,7 +84,10 @@ function ShowDetails(
               onClick={(e) =>
                 ToUpdate(block_number, item["id"], item["event_id"])
               }
-              disabled={item["id"] > current.id || !item["players_checked"]}
+              disabled={
+                !operation_unlock &&
+                (item["id"] > current.id || !item["players_checked"])
+              }
               sx={{ width: "5rem", marginBottom: "5px" }}
             >
               結果修正
@@ -78,7 +103,10 @@ function ShowDetails(
         variant="contained"
         type="submit"
         onClick={(e) => ToCall(block_number, item["id"], item["event_id"])}
-        disabled={item["id"] !== current.id || !item["players_checked"]}
+        disabled={
+          item["id"] !== current.id ||
+          (!operation_unlock && !item["players_checked"])
+        }
       >
         呼び出し
       </Button>
@@ -87,7 +115,10 @@ function ShowDetails(
         variant="contained"
         type="submit"
         onClick={(e) => ToRecord(block_number, item["id"], item["event_id"])}
-        disabled={item["id"] !== current.id || !item["players_checked"]}
+        disabled={
+          item["id"] !== current.id ||
+          (!operation_unlock && !item["players_checked"])
+        }
       >
         記録
       </Button>
@@ -96,7 +127,10 @@ function ShowDetails(
         variant="contained"
         type="submit"
         onClick={(e) => ToUpdate(block_number, item["id"], item["event_id"])}
-        disabled={item["id"] > current.id || !item["players_checked"]}
+        disabled={
+          !operation_unlock &&
+          (item["id"] > current.id || !item["players_checked"])
+        }
       >
         結果修正
       </Button>
@@ -169,6 +203,7 @@ function Block({
   return_url,
   correction = false,
   correction_return_url,
+  show_operation_unlock = false,
 }) {
   const router = useRouter();
   const ToCheck = (block_number, id, name, event_id) => {
@@ -244,6 +279,7 @@ function Block({
   };
   const [data, setData] = useState([]);
   const [current, setCurrent] = useState([]);
+  const [operationUnlock, setOperationUnlock] = useState(false);
 
   const fetchData = useCallback(async () => {
     const response = await fetch(
@@ -270,6 +306,29 @@ function Block({
     const result = await response.json();
     setCurrent(result);
   }, [block_number]);
+  const fetchOperationUnlock = useCallback(async () => {
+    if (!show_operation_unlock) {
+      return;
+    }
+    const response = await fetch("/api/operation_unlock?block=" + block_number);
+    const result = await response.json();
+    setOperationUnlock(result.enabled === true);
+  }, [block_number, show_operation_unlock]);
+  const updateOperationUnlock = async (enabled) => {
+    const response = await fetch("/api/operation_unlock", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ block: block_number, enabled }),
+    });
+    if (!response.ok) {
+      alert("操作制限解除の更新に失敗しました");
+      return;
+    }
+    const result = await response.json();
+    setOperationUnlock(result.enabled === true);
+  };
   const forceFetchCurrent = () => {
     fetchCurrent();
   };
@@ -345,6 +404,9 @@ function Block({
       clearInterval(interval);
     };
   }, [fetchCurrent, update_interval]);
+  useEffect(() => {
+    fetchOperationUnlock();
+  }, [fetchOperationUnlock]);
   const doneButtonStyle = {
     backgroundColor: "purple",
   };
@@ -372,6 +434,18 @@ function Block({
               style={{ height: "40px", color: "#b71c1c", fontWeight: "bold" }}
             >
               進行調整モード
+            </Grid>
+          ) : (
+            <></>
+          )}
+          {operationUnlock ? (
+            <Grid
+              container
+              justifyContent="center"
+              alignItems="center"
+              style={{ height: "40px", color: "#b71c1c", fontWeight: "bold" }}
+            >
+              操作制限解除中
             </Grid>
           ) : (
             <></>
@@ -475,6 +549,7 @@ function Block({
                             ToRecord,
                             ToUpdate,
                             ToFinish,
+                            operationUnlock,
                           )
                         ) : (
                           <></>
@@ -496,6 +571,22 @@ function Block({
               戻る
             </Button>
           </Grid>
+          {show_operation_unlock ? (
+            <Grid container justifyContent="center" alignItems="center">
+              <Box sx={{ textAlign: "center" }}>
+                <Button
+                  variant={operationUnlock ? "contained" : "outlined"}
+                  color={operationUnlock ? "error" : "primary"}
+                  type="submit"
+                  onClick={(e) => updateOperationUnlock(!operationUnlock)}
+                >
+                  操作制限解除 {operationUnlock ? "ON" : "OFF"}
+                </Button>
+              </Box>
+            </Grid>
+          ) : (
+            <></>
+          )}
         </Box>
       </Container>
     </div>

--- a/pages/admin/block.js
+++ b/pages/admin/block.js
@@ -22,6 +22,7 @@ const Home = () => {
         return_url="/admin"
         correction={correction === "true"}
         correction_return_url="/admin/corrections"
+        show_operation_unlock={true}
       />
     </>
   );

--- a/pages/api/get_games_on_block.js
+++ b/pages/api/get_games_on_block.js
@@ -42,20 +42,25 @@ async function GetFromDB(req, res, event_name) {
     block_name +
     " AS t1 ON t0.id = t1.id";
   let result = await client.query(query);
-  if (
-    req.query.schedule_id !== undefined &&
-    parseInt(req.query.schedule_id) !== result.rows[0].id
-  ) {
+  const current_schedule_id = result.rows[0].id;
+  const current_order_id = result.rows[0].game_id;
+  let schedule_id =
+    req.query.schedule_id !== undefined
+      ? parseInt(req.query.schedule_id)
+      : current_schedule_id;
+  if (schedule_id < current_schedule_id) {
     return [];
   }
-  let schedule_id = result.rows[0].id;
-  query =
-    "SELECT game_id from " +
-    block_name +
-    "_games where order_id = $1 and schedule_id = $2";
-  let values = [result.rows[0].game_id, result.rows[0].id];
-  result = await client.query(query, values);
-  const current_id = result.rows.length === 0 ? -1 : result.rows[0].game_id;
+  let current_id = -1;
+  if (schedule_id === current_schedule_id) {
+    query =
+      "SELECT game_id from " +
+      block_name +
+      "_games where order_id = $1 and schedule_id = $2";
+    let values = [current_order_id, current_schedule_id];
+    result = await client.query(query, values);
+    current_id = result.rows.length === 0 ? -1 : result.rows[0].game_id;
+  }
   let result_block;
   if (event_name.includes("dantai")) {
     const groups_name = event_name + "_groups";
@@ -319,11 +324,16 @@ const GetGamesOnBlock = async (req, res) => {
     const block_name = "block_" + req.query.block_number;
     const current_block_name = "current_" + block_name;
     const event_name = req.query.event_name;
-    const cacheKey = "get_games_on_" + block_name;
+    const cacheKey =
+      "get_games_on_" +
+      block_name +
+      "_" +
+      event_name +
+      "_" +
+      (req.query.schedule_id || "current");
     const cachedData = await Get(cacheKey);
 
-    // 'update_id_for_' +current_block_name can be checked,
-    // but only game id should be enough in the current logic
+    const latestIdUpdateKey = "update_id_for_" + current_block_name;
     const latestGameIdUpdateKey = "update_game_id_for_" + current_block_name;
     const latestChangeOrderKey = "change_order_for_" + block_name;
     const latestUpdateResultKey =
@@ -331,6 +341,7 @@ const GetGamesOnBlock = async (req, res) => {
     const latestCompletePlayersKey =
       "update_complete_players_for_" + block_name;
 
+    const latestIdUpdateTimestamp = (await Get(latestIdUpdateKey)) || 0;
     const latestGameIdUpdateTimestamp = (await Get(latestGameIdUpdateKey)) || 0;
     const latestChangeOrderTimestamp = (await Get(latestChangeOrderKey)) || 0;
     const latestUpdateResultTimestamp = (await Get(latestUpdateResultKey)) || 0;
@@ -338,6 +349,7 @@ const GetGamesOnBlock = async (req, res) => {
       (await Get(latestCompletePlayersKey)) || 0;
     if (
       cachedData &&
+      latestIdUpdateTimestamp < cachedData.timestamp &&
       latestGameIdUpdateTimestamp < cachedData.timestamp &&
       latestChangeOrderTimestamp < cachedData.timestamp &&
       latestUpdateResultTimestamp < cachedData.timestamp &&

--- a/pages/api/get_table_progress_on_block.js
+++ b/pages/api/get_table_progress_on_block.js
@@ -13,20 +13,25 @@ async function GetFromDB(req, res, event_name) {
     block_name +
     " AS t1 ON t0.id = t1.id";
   let result = await client.query(query);
-  if (
-    req.query.schedule_id !== undefined &&
-    parseInt(req.query.schedule_id) !== result.rows[0].id
-  ) {
+  const current_schedule_id = result.rows[0].id;
+  const current_order_id = result.rows[0].game_id;
+  let schedule_id =
+    req.query.schedule_id !== undefined
+      ? parseInt(req.query.schedule_id)
+      : current_schedule_id;
+  if (schedule_id < current_schedule_id) {
     return [];
   }
-  let schedule_id = result.rows[0].id;
-  query =
-    "SELECT game_id from " +
-    block_name +
-    "_games where order_id = $1 and schedule_id = $2";
-  let values = [result.rows[0].game_id, result.rows[0].id];
-  result = await client.query(query, values);
-  const current_id = result.rows.length === 0 ? -1 : result.rows[0].game_id;
+  let current_id = -1;
+  if (schedule_id === current_schedule_id) {
+    query =
+      "SELECT game_id from " +
+      block_name +
+      "_games where order_id = $1 and schedule_id = $2";
+    let values = [current_order_id, current_schedule_id];
+    result = await client.query(query, values);
+    current_id = result.rows.length === 0 ? -1 : result.rows[0].game_id;
+  }
   const groups_name = event_name + "_groups";
   query =
     "SELECT t0.order_id, t1.id, t1.retire, t2.name" +
@@ -57,11 +62,16 @@ const GetTableProgressOnBlock = async (req, res) => {
     const block_name = "block_" + req.query.block_number;
     const current_block_name = "current_" + block_name;
     const event_name = req.query.event_name;
-    const cacheKey = "get_games_on_" + block_name;
+    const cacheKey =
+      "get_table_progress_on_" +
+      block_name +
+      "_" +
+      event_name +
+      "_" +
+      (req.query.schedule_id || "current");
     const cachedData = await Get(cacheKey);
 
-    // 'update_id_for_' +current_block_name can be checked,
-    // but only game id should be enough in the current logic
+    const latestIdUpdateKey = "update_id_for_" + current_block_name;
     const latestGameIdUpdateKey = "update_game_id_for_" + current_block_name;
     const latestChangeOrderKey = "change_order_for_" + block_name;
     const latestUpdateResultKey =
@@ -69,6 +79,7 @@ const GetTableProgressOnBlock = async (req, res) => {
     const latestCompletePlayersKey =
       "update_complete_players_for_" + block_name;
 
+    const latestIdUpdateTimestamp = (await Get(latestIdUpdateKey)) || 0;
     const latestGameIdUpdateTimestamp = (await Get(latestGameIdUpdateKey)) || 0;
     const latestChangeOrderTimestamp = (await Get(latestChangeOrderKey)) || 0;
     const latestUpdateResultTimestamp = (await Get(latestUpdateResultKey)) || 0;
@@ -76,6 +87,7 @@ const GetTableProgressOnBlock = async (req, res) => {
       (await Get(latestCompletePlayersKey)) || 0;
     if (
       cachedData &&
+      latestIdUpdateTimestamp < cachedData.timestamp &&
       latestGameIdUpdateTimestamp < cachedData.timestamp &&
       latestChangeOrderTimestamp < cachedData.timestamp &&
       latestUpdateResultTimestamp < cachedData.timestamp &&

--- a/pages/api/operation_unlock.js
+++ b/pages/api/operation_unlock.js
@@ -1,0 +1,34 @@
+import { Get, Set } from "../../lib/redis_client";
+
+function getKey(block) {
+  return "operation_unlock_for_block_" + block;
+}
+
+function isValidBlock(block) {
+  return typeof block === "string" && /^[a-z]$/.test(block);
+}
+
+const OperationUnlock = async (req, res) => {
+  try {
+    const block = req.method === "POST" ? req.body.block : req.query.block;
+    if (!isValidBlock(block)) {
+      res.status(400).json({ error: "invalid block" });
+      return;
+    }
+
+    if (req.method === "POST") {
+      const enabled = Boolean(req.body.enabled);
+      await Set(getKey(block), enabled ? "true" : "false");
+      res.json({ enabled });
+      return;
+    }
+
+    const enabled = (await Get(getKey(block))) === true;
+    res.json({ enabled });
+  } catch (error) {
+    console.log(error);
+    res.status(500).json({ error: "Error updating operation unlock" });
+  }
+};
+
+export default OperationUnlock;


### PR DESCRIPTION
緊急時用に、操作制限解除ボタンを追加します。
ONにすると、以下が行えるようになります。
- 現在競技より後の競技も「呼び出し」と「結果修正」を押せるようになる (例えば先々の競技を別コートで同時実施することにした場合。コート移す変更は難しいので、せめて呼び出しと、記録を結果修正から行う。という対応が可能になる)
- 現在競技で点呼完了していなくても「呼び出し」「記録」を押せるようになる (例えば競技かぶりで点呼完了していないけど、進めたい場合)

コート内判断で解除できるよう、コートUIの一番下にボタン追加しています