### PR TITLE
run advance schedule script in parallel

### DIFF
--- a/doc/develop/playwright.md
+++ b/doc/develop/playwright.md
@@ -48,12 +48,33 @@ tools/advance-schedule.bash A B A C B
 この例では、A、B、A、C、Bの順に処理する。
 途中で失敗した場合は、その場で停止する。
 
+### コートごとに並列実行する
+
+`--parallel`を指定すると、異なるコートを並列に処理する。
+同じコートの競技は、指定した順番どおりに処理される。
+
+```bash
+tools/advance-schedule.bash --parallel A B A C B
+```
+
+この例ではA、B、Cコートを並列に処理し、各コート内では指定順を維持する。
+ログの先頭には`[court A]`のようにコート名が表示される。
+
+いずれかのコートで失敗しても、実行中のほかのコートは処理を続ける。
+すべてのコートが終了した後、1つでも失敗していればコマンド全体がエラーで終了する。
+
 ## 計画ファイルを使う
 
 実行順が長い場合は、計画ファイルを使用する。
 
 ```bash
 tools/advance-schedule.bash --file e2e/advance-plan.txt
+```
+
+コートごとに並列実行する場合は`--parallel`を追加する。
+
+```bash
+tools/advance-schedule.bash --parallel --file e2e/advance-plan.txt
 ```
 
 計画ファイルには、1行につきコートと現在競技IDを記述する。

--- a/e2e/tests/advance-schedule.spec.ts
+++ b/e2e/tests/advance-schedule.spec.ts
@@ -78,6 +78,12 @@ async function waitForApp(page: Page) {
     .toBe(200);
 }
 
+async function waitForRecordData(page: Page) {
+  await expect(
+    page.getByRole("heading", { name: /^第[1-9]\d*試合$/ }),
+  ).toBeVisible({ timeout: 15_000 });
+}
+
 async function markEveryonePresent(page: Page) {
   const radios = page.locator('input[type="radio"]');
   await expect
@@ -481,6 +487,7 @@ test("指定コートの現在競技を完了し、次競技へ進める", async
     }
     visitedPositions.add(position);
 
+    await waitForRecordData(page);
     const result = page.url().includes("record_table_result")
       ? await fillTableScores(page)
       : await recordTournamentGame(page);

--- a/tools/advance-schedule.bash
+++ b/tools/advance-schedule.bash
@@ -7,8 +7,8 @@ REPOSITORY_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
 
 usage() {
     echo "Usage:"
-    echo "  tools/advance-schedule.bash A [B ...]"
-    echo "  tools/advance-schedule.bash --file PATH"
+    echo "  tools/advance-schedule.bash [--parallel] A [B ...]"
+    echo "  tools/advance-schedule.bash [--parallel] --file PATH"
 }
 
 append_step() {
@@ -28,21 +28,51 @@ append_step() {
     EXPECTED_SCHEDULE_IDS+=("${expected_schedule_id}")
 }
 
-if [[ $# -eq 0 ]]; then
-    usage
-    exit 1
-fi
-
 declare -a COURTS=()
 declare -a EXPECTED_SCHEDULE_IDS=()
+declare -a COURT_ARGUMENTS=()
+PARALLEL=false
+PLAN_FILE=""
 
-if [[ $1 == "--file" ]]; then
-    if [[ $# -ne 2 ]]; then
-        usage
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --parallel)
+            if [[ "${PARALLEL}" == true ]]; then
+                echo "--parallel may only be specified once." >&2
+                exit 1
+            fi
+            PARALLEL=true
+            shift
+            ;;
+        --file)
+            if [[ -n "${PLAN_FILE}" ]]; then
+                echo "--file may only be specified once." >&2
+                exit 1
+            fi
+            if [[ $# -lt 2 ]]; then
+                usage
+                exit 1
+            fi
+            PLAN_FILE=$2
+            shift 2
+            ;;
+        --*)
+            echo "Unknown option: $1" >&2
+            usage
+            exit 1
+            ;;
+        *)
+            COURT_ARGUMENTS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if [[ -n "${PLAN_FILE}" ]]; then
+    if [[ ${#COURT_ARGUMENTS[@]} -gt 0 ]]; then
+        echo "Court arguments cannot be combined with --file." >&2
         exit 1
     fi
-
-    PLAN_FILE=$2
     if [[ ! -f "${PLAN_FILE}" ]]; then
         echo "Plan file not found: ${PLAN_FILE}" >&2
         exit 1
@@ -63,7 +93,7 @@ if [[ $1 == "--file" ]]; then
         append_step "${court}" "${expected_schedule_id:-}"
     done < "${PLAN_FILE}"
 else
-    for court in "$@"; do
+    for court in "${COURT_ARGUMENTS[@]}"; do
         append_step "${court}"
     done
 fi
@@ -92,25 +122,87 @@ PLAYWRIGHT_GID="$(id -g)" \
 
 TOTAL_STEPS=${#COURTS[@]}
 
-for ((index = 0; index < TOTAL_STEPS; index += 1)); do
-    COURT=${COURTS[index]}
-    EXPECTED_SCHEDULE_ID=${EXPECTED_SCHEDULE_IDS[index]}
-    STEP_NUMBER=$((index + 1))
-    if [[ -n "${EXPECTED_SCHEDULE_ID}" ]]; then
-        echo "[advance-plan] [${STEP_NUMBER}/${TOTAL_STEPS}] court=${COURT} expected_schedule=${EXPECTED_SCHEDULE_ID}"
+run_step() {
+    local index=$1
+    local court=${COURTS[index]}
+    local expected_schedule_id=${EXPECTED_SCHEDULE_IDS[index]}
+    local step_number=$((index + 1))
+
+    if [[ -n "${expected_schedule_id}" ]]; then
+        echo "[advance-plan] [${step_number}/${TOTAL_STEPS}] court=${court} expected_schedule=${expected_schedule_id}"
     else
-        echo "[advance-plan] [${STEP_NUMBER}/${TOTAL_STEPS}] court=${COURT}"
+        echo "[advance-plan] [${step_number}/${TOTAL_STEPS}] court=${court}"
     fi
 
-    COURT="${COURT}" \
-    CONFIRM_ADVANCE="${COURT}" \
-    EXPECTED_SCHEDULE_ID="${EXPECTED_SCHEDULE_ID}" \
-    PLAYWRIGHT_UID="$(id -u)" \
-    PLAYWRIGHT_GID="$(id -g)" \
-    "${COMPOSE[@]}" run \
-        --rm \
-        --no-deps \
-        playwright
-done
+    if [[ "${PARALLEL}" == true ]]; then
+        COURT="${court}" \
+        CONFIRM_ADVANCE="${court}" \
+        EXPECTED_SCHEDULE_ID="${expected_schedule_id}" \
+        PLAYWRIGHT_UID="$(id -u)" \
+        PLAYWRIGHT_GID="$(id -g)" \
+        "${COMPOSE[@]}" run \
+            --rm \
+            --no-deps \
+            -T \
+            playwright 2>&1 | sed -u "s/^/[court ${court}] /"
+    else
+        COURT="${court}" \
+        CONFIRM_ADVANCE="${court}" \
+        EXPECTED_SCHEDULE_ID="${expected_schedule_id}" \
+        PLAYWRIGHT_UID="$(id -u)" \
+        PLAYWRIGHT_GID="$(id -g)" \
+        "${COMPOSE[@]}" run \
+            --rm \
+            --no-deps \
+            -T \
+            playwright
+    fi
+}
+
+run_court_steps() {
+    local court=$1
+    local index
+    for index in ${COURT_STEP_INDICES[${court}]}; do
+        run_step "${index}"
+    done
+}
+
+if [[ "${PARALLEL}" == true ]]; then
+    declare -A COURT_STEP_INDICES=()
+    declare -a UNIQUE_COURTS=()
+    declare -a WORKER_PIDS=()
+    declare -a WORKER_COURTS=()
+
+    for ((index = 0; index < TOTAL_STEPS; index += 1)); do
+        court=${COURTS[index]}
+        if [[ -z "${COURT_STEP_INDICES[${court}]+set}" ]]; then
+            UNIQUE_COURTS+=("${court}")
+            COURT_STEP_INDICES[${court}]=""
+        fi
+        COURT_STEP_INDICES[${court}]+=" ${index}"
+    done
+
+    echo "[advance-plan] parallel courts: ${UNIQUE_COURTS[*]}"
+    for court in "${UNIQUE_COURTS[@]}"; do
+        run_court_steps "${court}" &
+        WORKER_PIDS+=("$!")
+        WORKER_COURTS+=("${court}")
+    done
+
+    FAILED=0
+    for ((index = 0; index < ${#WORKER_PIDS[@]}; index += 1)); do
+        if ! wait "${WORKER_PIDS[index]}"; then
+            echo "[advance-plan] court=${WORKER_COURTS[index]} failed" >&2
+            FAILED=1
+        fi
+    done
+    if [[ ${FAILED} -ne 0 ]]; then
+        exit 1
+    fi
+else
+    for ((index = 0; index < TOTAL_STEPS; index += 1)); do
+        run_step "${index}"
+    done
+fi
 
 echo "[advance-plan] completed ${TOTAL_STEPS} step(s)"


### PR DESCRIPTION
スケジュール進行をテストするスクリプトを、コート毎に並列に走らせる機能をサポートします(同時進行で問題ないかの確認と、テスト速度を単に早めるため)