### PR TITLE
fix redis cache functionality

### DIFF
--- a/lib/redis_client.js
+++ b/lib/redis_client.js
@@ -39,6 +39,19 @@ export async function Get(key) {
   }
 }
 
+export async function GetMany(keys) {
+  let values;
+  try {
+    const client = await connectToRedis();
+    values = await client.mGet(keys);
+  } catch (err) {
+    return keys.map(() => null);
+  }
+  return values.map((value) =>
+    typeof value === "string" ? JSON.parse(value) : value,
+  );
+}
+
 export async function Set(key, value) {
   try {
     const client = await connectToRedis();
@@ -51,6 +64,24 @@ export async function Set(key, value) {
     return;
   }
   return;
+}
+
+export async function Increment(key) {
+  try {
+    const client = await connectToRedis();
+    return await client.incr(key);
+  } catch (err) {
+    return null;
+  }
+}
+
+export async function Delete(key) {
+  try {
+    const client = await connectToRedis();
+    await client.del(key);
+  } catch (err) {
+    return;
+  }
 }
 
 export async function FlushAll() {

--- a/lib/redis_client.js
+++ b/lib/redis_client.js
@@ -75,15 +75,6 @@ export async function Increment(key) {
   }
 }
 
-export async function Delete(key) {
-  try {
-    const client = await connectToRedis();
-    await client.del(key);
-  } catch (err) {
-    return;
-  }
-}
-
 export async function FlushAll() {
   try {
     const client = await connectToRedis();

--- a/lib/result_cache.js
+++ b/lib/result_cache.js
@@ -1,0 +1,25 @@
+import { Delete } from "./redis_client";
+import { GetVersionedCache, TouchCacheVersion } from "./versioned_cache";
+
+function timestampKey(eventName) {
+  return `latest_update_result_for_${eventName}_timestamp`;
+}
+
+function cacheKey(eventName) {
+  return `get_result_for_${eventName}_cache_data`;
+}
+
+export async function MarkResultUpdated(eventName) {
+  await Promise.all([
+    TouchCacheVersion(timestampKey(eventName)),
+    Delete(cacheKey(eventName)),
+  ]);
+}
+
+export async function GetResultWithCache(eventName, loadData) {
+  return GetVersionedCache(
+    cacheKey(eventName),
+    [timestampKey(eventName)],
+    loadData,
+  );
+}

--- a/lib/result_cache.js
+++ b/lib/result_cache.js
@@ -1,4 +1,3 @@
-import { Delete } from "./redis_client";
 import { GetVersionedCache, TouchCacheVersion } from "./versioned_cache";
 
 function timestampKey(eventName) {
@@ -10,10 +9,7 @@ function cacheKey(eventName) {
 }
 
 export async function MarkResultUpdated(eventName) {
-  await Promise.all([
-    TouchCacheVersion(timestampKey(eventName)),
-    Delete(cacheKey(eventName)),
-  ]);
+  await TouchCacheVersion(timestampKey(eventName));
 }
 
 export async function GetResultWithCache(eventName, loadData) {

--- a/lib/result_cache.js
+++ b/lib/result_cache.js
@@ -1,7 +1,7 @@
 import { GetVersionedCache, TouchCacheVersion } from "./versioned_cache";
 
-function timestampKey(eventName) {
-  return `latest_update_result_for_${eventName}_timestamp`;
+function versionKey(eventName) {
+  return `latest_update_result_for_${eventName}_version`;
 }
 
 function cacheKey(eventName) {
@@ -9,13 +9,13 @@ function cacheKey(eventName) {
 }
 
 export async function MarkResultUpdated(eventName) {
-  await TouchCacheVersion(timestampKey(eventName));
+  await TouchCacheVersion(versionKey(eventName));
 }
 
 export async function GetResultWithCache(eventName, loadData) {
   return GetVersionedCache(
     cacheKey(eventName),
-    [timestampKey(eventName)],
+    [versionKey(eventName)],
     loadData,
   );
 }

--- a/lib/versioned_cache.js
+++ b/lib/versioned_cache.js
@@ -1,0 +1,57 @@
+import { GetMany, Increment, Set } from "./redis_client";
+
+const CACHE_RETRIES = 2;
+
+function normalizeVersion(value) {
+  const version = Number(value);
+  return Number.isInteger(version) && version >= 0 ? version : 0;
+}
+
+async function getVersions(versionKeys) {
+  const values = await GetMany(versionKeys);
+  return values.map(normalizeVersion);
+}
+
+function versionsMatch(left, right) {
+  return (
+    Array.isArray(left) &&
+    left.length === right.length &&
+    left.every((version, index) => version === right[index])
+  );
+}
+
+export async function TouchCacheVersion(key) {
+  return Increment(key);
+}
+
+export async function GetVersionedCache(
+  cacheKey,
+  versionKeys,
+  loadData,
+  shouldCache = () => true,
+) {
+  const initialValues = await GetMany([cacheKey, ...versionKeys]);
+  const cached = initialValues[0];
+  let versions = initialValues.slice(1).map(normalizeVersion);
+
+  if (cached && versionsMatch(cached.versions, versions)) {
+    return cached.data;
+  }
+
+  let data;
+  for (let attempt = 0; attempt < CACHE_RETRIES; attempt += 1) {
+    const versionsBefore = versions;
+    data = await loadData();
+    const versionsAfter = await getVersions(versionKeys);
+
+    if (versionsMatch(versionsBefore, versionsAfter)) {
+      if (shouldCache(data)) {
+        await Set(cacheKey, { data, versions: versionsAfter });
+      }
+      return data;
+    }
+    versions = versionsAfter;
+  }
+
+  return data;
+}

--- a/pages/api/back.js
+++ b/pages/api/back.js
@@ -1,5 +1,5 @@
 import GetClient from "../../lib/db_client";
-import { Set } from "../../lib/redis_client";
+import { TouchCacheVersion } from "../../lib/versioned_cache";
 
 const Back = async (req, res) => {
   try {
@@ -11,8 +11,7 @@ const Back = async (req, res) => {
       query = "update " + current_block_name + " set game_id = game_id - 1";
       result = await client.query(query);
       const key = "update_game_id_for_" + current_block_name;
-      const timestamp = Date.now();
-      await Set(key, timestamp);
+      await TouchCacheVersion(key);
     }
     res.json({});
   } catch (error) {

--- a/pages/api/change_event_order.js
+++ b/pages/api/change_event_order.js
@@ -1,5 +1,5 @@
 import GetClient from "../../lib/db_client";
-import { Set } from "../../lib/redis_client";
+import { TouchCacheVersion } from "../../lib/versioned_cache";
 
 const ChangeEventOrder = async (req, res) => {
   try {
@@ -23,8 +23,7 @@ const ChangeEventOrder = async (req, res) => {
     values = [target_schedule_id, target_schedule_id + 1];
     result = await client.query(query, values);
     const key = "change_event_order_for_" + block_name;
-    const timestamp = Date.now();
-    await Set(key, timestamp);
+    await TouchCacheVersion(key);
     res.json({});
   } catch (error) {
     console.log(error);

--- a/pages/api/change_order.js
+++ b/pages/api/change_order.js
@@ -1,5 +1,5 @@
 import GetClient from "../../lib/db_client";
-import { Set } from "../../lib/redis_client";
+import { TouchCacheVersion } from "../../lib/versioned_cache";
 
 const ChangeOrder = async (req, res) => {
   try {
@@ -17,8 +17,7 @@ const ChangeOrder = async (req, res) => {
     let values = [req.body.target_order_id, req.body.target_order_id + 1];
     const result = await client.query(query, values);
     const key = "change_order_for_" + block_name;
-    const timestamp = Date.now();
-    await Set(key, timestamp);
+    await TouchCacheVersion(key);
     res.json({});
   } catch (error) {
     console.log(error);

--- a/pages/api/check_players_on_block.js
+++ b/pages/api/check_players_on_block.js
@@ -1,6 +1,6 @@
 import GetClient from "../../lib/db_client";
-import { Get, Set } from "../../lib/redis_client";
 import { GetEventName } from "../../lib/get_event_name";
+import { GetVersionedCache } from "../../lib/versioned_cache";
 
 function update(sorted_data, item, block_indices, value, round) {
   if ("prev_left_id" in item) {
@@ -432,62 +432,49 @@ const CheckPlayersOnBlock = async (req, res) => {
     const block_name = "block_" + req.query.block_number;
     const cacheKey =
       "check_players_on_" + block_name + "_for_" + req.query.schedule_id;
-    const cachedData = await Get(cacheKey);
     const notification_request_name = is_test
       ? "test_notification_request"
       : "notification_request";
     const latestNotificationUpdateKey =
       "latest_update_for_" + notification_request_name;
-    const latestNotificationUpdateTimestamp =
-      (await Get(latestNotificationUpdateKey)) || 0;
     const latestCompletePlayersKey =
       "update_complete_players_for_" + block_name;
-    const latestCompletePlayersTimestamp =
-      (await Get(latestCompletePlayersKey)) || 0;
     if (GetEventName(event_id) === "dantai") {
-      if (
-        cachedData &&
-        latestNotificationUpdateTimestamp < cachedData.timestamp &&
-        latestCompletePlayersTimestamp < cachedData.timestamp
-      ) {
-        console.log("using cache");
-        return res.json(cachedData.data);
-      }
-      console.log("get new data");
-      const data = await GetDantaiFromDB(
-        req,
-        res,
-        event_id,
-        is_test,
-        notification_request_name,
+      const data = await GetVersionedCache(
+        cacheKey,
+        [latestNotificationUpdateKey, latestCompletePlayersKey],
+        () =>
+          GetDantaiFromDB(
+            req,
+            res,
+            event_id,
+            is_test,
+            notification_request_name,
+          ),
       );
-      await Set(cacheKey, { data: data, timestamp: Date.now() });
       return res.json(data);
     }
     const event_name = (is_test ? "test_" : "") + GetEventName(event_id);
     const players_name = is_test ? "test_players" : "players";
     const latestResultUpdateKey =
       "latest_update_result_for_" + event_name + "_timestamp";
-    const latestResultUpdateTimestamp = (await Get(latestResultUpdateKey)) || 0;
-    if (
-      cachedData &&
-      latestResultUpdateTimestamp < cachedData.timestamp &&
-      latestNotificationUpdateTimestamp < cachedData.timestamp &&
-      latestCompletePlayersTimestamp < cachedData.timestamp
-    ) {
-      console.log("using cache");
-      return res.json(cachedData.data);
-    }
-    console.log("get new data");
-    const data = await GetFromDB(
-      req,
-      res,
-      event_id,
-      event_name,
-      players_name,
-      notification_request_name,
+    const data = await GetVersionedCache(
+      cacheKey,
+      [
+        latestResultUpdateKey,
+        latestNotificationUpdateKey,
+        latestCompletePlayersKey,
+      ],
+      () =>
+        GetFromDB(
+          req,
+          res,
+          event_id,
+          event_name,
+          players_name,
+          notification_request_name,
+        ),
     );
-    await Set(cacheKey, { data: data, timestamp: Date.now() });
     return res.json(data);
   } catch (error) {
     console.log(error);

--- a/pages/api/check_players_on_block.js
+++ b/pages/api/check_players_on_block.js
@@ -457,7 +457,7 @@ const CheckPlayersOnBlock = async (req, res) => {
     const event_name = (is_test ? "test_" : "") + GetEventName(event_id);
     const players_name = is_test ? "test_players" : "players";
     const latestResultUpdateKey =
-      "latest_update_result_for_" + event_name + "_timestamp";
+      "latest_update_result_for_" + event_name + "_version";
     const data = await GetVersionedCache(
       cacheKey,
       [

--- a/pages/api/check_table_groups_on_block.js
+++ b/pages/api/check_table_groups_on_block.js
@@ -1,6 +1,6 @@
 import GetClient from "../../lib/db_client";
-import { Get, Set } from "../../lib/redis_client";
 import { GetEventName } from "../../lib/get_event_name";
+import { GetVersionedCache } from "../../lib/versioned_cache";
 
 async function GetFromDB(
   req,
@@ -60,40 +60,26 @@ const CheckTableGroupsOnBlock = async (req, res) => {
     const block_name = "block_" + req.query.block_number;
     const cacheKey =
       "check_table_groups_on_" + block_name + "_for_" + req.query.schedule_id;
-    const cachedData = await Get(cacheKey);
     const notification_request_name = is_test
       ? "test_notification_request"
       : "notification_request";
     const latestNotificationUpdateKey =
       "latest_update_for_" + notification_request_name;
-    const latestNotificationUpdateTimestamp =
-      (await Get(latestNotificationUpdateKey)) || 0;
     const latestCompleteTableGroupsKey =
       "update_complete_players_for_" + block_name;
-    const latestCompleteTableGroupsTimestamp =
-      (await Get(latestCompleteTableGroupsKey)) || 0;
     const event_name = (is_test ? "test_" : "") + GetEventName(event_id);
     const latestResultUpdateKey =
       "latest_update_result_for_" + event_name + "_timestamp";
-    const latestResultUpdateTimestamp = (await Get(latestResultUpdateKey)) || 0;
-    if (
-      cachedData &&
-      latestResultUpdateTimestamp < cachedData.timestamp &&
-      latestNotificationUpdateTimestamp < cachedData.timestamp &&
-      latestCompleteTableGroupsTimestamp < cachedData.timestamp
-    ) {
-      console.log("using cache");
-      return res.json(cachedData.data);
-    }
-    console.log("get new data");
-    const data = await GetFromDB(
-      req,
-      res,
-      event_id,
-      event_name,
-      notification_request_name,
+    const data = await GetVersionedCache(
+      cacheKey,
+      [
+        latestResultUpdateKey,
+        latestNotificationUpdateKey,
+        latestCompleteTableGroupsKey,
+      ],
+      () =>
+        GetFromDB(req, res, event_id, event_name, notification_request_name),
     );
-    await Set(cacheKey, { data: data, timestamp: Date.now() });
     return res.json(data);
   } catch (error) {
     console.log(error);

--- a/pages/api/check_table_groups_on_block.js
+++ b/pages/api/check_table_groups_on_block.js
@@ -69,7 +69,7 @@ const CheckTableGroupsOnBlock = async (req, res) => {
       "update_complete_players_for_" + block_name;
     const event_name = (is_test ? "test_" : "") + GetEventName(event_id);
     const latestResultUpdateKey =
-      "latest_update_result_for_" + event_name + "_timestamp";
+      "latest_update_result_for_" + event_name + "_version";
     const data = await GetVersionedCache(
       cacheKey,
       [

--- a/pages/api/clear_notification_request.js
+++ b/pages/api/clear_notification_request.js
@@ -1,5 +1,5 @@
 import GetClient from "../../lib/db_client";
-import { Set } from "../../lib/redis_client";
+import { TouchCacheVersion } from "../../lib/versioned_cache";
 
 const ClearNotificationRequest = async (req, res) => {
   try {
@@ -36,7 +36,7 @@ const ClearNotificationRequest = async (req, res) => {
       console.log(result);
     }
     const key = "latest_update_for_" + notification_request_name;
-    Set(key, Date.now());
+    await TouchCacheVersion(key);
     res.json({});
   } catch (error) {
     console.log(error);

--- a/pages/api/complete_players_check.js
+++ b/pages/api/complete_players_check.js
@@ -1,6 +1,7 @@
 import GetClient from "../../lib/db_client";
-import { Get, Set } from "../../lib/redis_client";
 import { GetEventName } from "../../lib/get_event_name";
+import { MarkResultUpdated } from "../../lib/result_cache";
+import { TouchCacheVersion } from "../../lib/versioned_cache";
 
 const CompletePlayersCheck = async (req, res) => {
   try {
@@ -61,11 +62,9 @@ const CompletePlayersCheck = async (req, res) => {
       result = await client.query(query);
     }
     const key = "update_complete_players_for_block_" + req.body.block_number;
-    const timestamp = Date.now();
-    await Set(key, timestamp);
+    await TouchCacheVersion(key);
     // for retire state updates in admin
-    const result_key = "latest_update_result_for_" + event_name + "_timestamp";
-    await Set(result_key, timestamp);
+    await MarkResultUpdated(event_name);
     res.json({});
   } catch (error) {
     console.log(error);

--- a/pages/api/complete_schedule.js
+++ b/pages/api/complete_schedule.js
@@ -1,5 +1,5 @@
 import GetClient from "../../lib/db_client";
-import { Get, Set } from "../../lib/redis_client";
+import { TouchCacheVersion } from "../../lib/versioned_cache";
 
 const CompleteSchedule = async (req, res) => {
   try {
@@ -9,11 +9,12 @@ const CompleteSchedule = async (req, res) => {
     const query =
       "update " + current_block_name + " set id = " + next_id + ", game_id = 1";
     const result = await client.query(query);
-    const timestamp = Date.now();
     const update_game_id_key = "update_game_id_for_" + current_block_name;
     const update_id_key = "update_id_for_" + current_block_name;
-    await Set(update_game_id_key, timestamp);
-    await Set(update_id_key, timestamp);
+    await Promise.all([
+      TouchCacheVersion(update_game_id_key),
+      TouchCacheVersion(update_id_key),
+    ]);
     res.json({});
   } catch (error) {
     console.log(error);

--- a/pages/api/confirm_table_result.js
+++ b/pages/api/confirm_table_result.js
@@ -1,5 +1,5 @@
 import GetClient from "../../lib/db_client";
-import { Set } from "../../lib/redis_client";
+import { MarkResultUpdated } from "../../lib/result_cache";
 
 const Confirm = async (req, res) => {
   const client = await GetClient();
@@ -109,9 +109,7 @@ const Confirm = async (req, res) => {
         }
       }
     }
-    const key = "latest_update_result_for_" + event_name + "_timestamp";
-    const timestamp = Date.now();
-    await Set(key, timestamp);
+    await MarkResultUpdated(event_name);
   }
   res.json({});
 };

--- a/pages/api/create_notification_request.js
+++ b/pages/api/create_notification_request.js
@@ -1,5 +1,5 @@
 import GetClient from "../../lib/db_client";
-import { Get, Set } from "../../lib/redis_client";
+import { TouchCacheVersion } from "../../lib/versioned_cache";
 
 const CreateNotificationRequest = async (req, res) => {
   try {
@@ -32,7 +32,7 @@ const CreateNotificationRequest = async (req, res) => {
       result = await client.query(query, values);
     }
     const key = "latest_update_for_" + notification_request_name;
-    Set(key, Date.now());
+    await TouchCacheVersion(key);
     res.json({});
   } catch (error) {
     console.log(error);

--- a/pages/api/current_block.js
+++ b/pages/api/current_block.js
@@ -257,7 +257,7 @@ const CurrentBlock = async (req, res) => {
     const latestGameIdUpdateKey = "update_game_id_for_" + current_block_name;
     const latestChangeOrderKey = "change_order_for_" + block_name;
     const latestUpdateResultKey =
-      "latest_update_result_for_" + event_name + "_timestamp";
+      "latest_update_result_for_" + event_name + "_version";
     const latestCompletePlayersKey =
       "update_complete_players_for_" + block_name;
 

--- a/pages/api/current_block.js
+++ b/pages/api/current_block.js
@@ -1,6 +1,6 @@
 import GetClient from "../../lib/db_client";
-import { Get, Set } from "../../lib/redis_client";
 import { GetEventName } from "../../lib/get_event_name";
+import { GetVersionedCache } from "../../lib/versioned_cache";
 
 function update(sorted_data, item, block_indices, value, round) {
   if ("prev_left_id" in item) {
@@ -252,8 +252,6 @@ const CurrentBlock = async (req, res) => {
     const event_name = req.query.event_name;
     const cacheKey =
       "current_" + block_name + (event_name ? "_for_" + event_name : "");
-    const cachedData = await Get(cacheKey);
-
     // 'update_id_for_' +current_block_name can be checked,
     // but only game id should be enough in the current logic
     const latestGameIdUpdateKey = "update_game_id_for_" + current_block_name;
@@ -263,30 +261,17 @@ const CurrentBlock = async (req, res) => {
     const latestCompletePlayersKey =
       "update_complete_players_for_" + block_name;
 
-    const latestGameIdUpdateTimestamp = (await Get(latestGameIdUpdateKey)) || 0;
-    const latestChangeOrderTimestamp = (await Get(latestChangeOrderKey)) || 0;
-    const latestUpdateResultTimestamp = (await Get(latestUpdateResultKey)) || 0;
-    const latestCompletePlayersTimestamp =
-      (await Get(latestCompletePlayersKey)) || 0;
-    if (
-      cachedData &&
-      latestGameIdUpdateTimestamp < cachedData.timestamp &&
-      latestChangeOrderTimestamp < cachedData.timestamp &&
-      latestUpdateResultTimestamp < cachedData.timestamp &&
-      latestCompletePlayersTimestamp < cachedData.timestamp
-    ) {
-      console.log("using cache");
-      if (cachedData.data["event_name"] === event_name) {
-        return res.json(cachedData.data);
-      } else {
-        return res.json([]);
-      }
-    }
-    console.log("get new data");
-    const data = await GetFromDB(req, res);
-    if (req.query.schedule_id === undefined || data.length !== 0) {
-      await Set(cacheKey, { data: data, timestamp: Date.now() });
-    }
+    const data = await GetVersionedCache(
+      cacheKey,
+      [
+        latestGameIdUpdateKey,
+        latestChangeOrderKey,
+        latestUpdateResultKey,
+        latestCompletePlayersKey,
+      ],
+      () => GetFromDB(req, res),
+      (loaded) => req.query.schedule_id === undefined || loaded.length !== 0,
+    );
     res.json(data);
   } catch (error) {
     console.log(error);

--- a/pages/api/current_game_on_table.js
+++ b/pages/api/current_game_on_table.js
@@ -64,7 +64,7 @@ const CurrentGameOnTable = async (req, res) => {
     const latestGameIdUpdateKey = "update_game_id_for_" + current_block_name;
     const latestChangeOrderKey = "change_order_for_" + block_name;
     const latestUpdateResultKey =
-      "latest_update_result_for_" + event_name + "_timestamp";
+      "latest_update_result_for_" + event_name + "_version";
     const latestCompletePlayersKey =
       "update_complete_players_for_" + block_name;
 

--- a/pages/api/current_game_on_table.js
+++ b/pages/api/current_game_on_table.js
@@ -1,6 +1,6 @@
 import GetClient from "../../lib/db_client";
-import { Get, Set } from "../../lib/redis_client";
 import { GetEventName } from "../../lib/get_event_name";
+import { GetVersionedCache } from "../../lib/versioned_cache";
 
 async function GetFromDB(req, res) {
   const client = await GetClient();
@@ -59,8 +59,6 @@ const CurrentGameOnTable = async (req, res) => {
     const current_block_name = "current_" + block_name;
     const event_name = req.query.event_name;
     const cacheKey = "current_" + block_name;
-    const cachedData = await Get(cacheKey);
-
     // 'update_id_for_' +current_block_name can be checked,
     // but only game id should be enough in the current logic
     const latestGameIdUpdateKey = "update_game_id_for_" + current_block_name;
@@ -70,26 +68,17 @@ const CurrentGameOnTable = async (req, res) => {
     const latestCompletePlayersKey =
       "update_complete_players_for_" + block_name;
 
-    const latestGameIdUpdateTimestamp = (await Get(latestGameIdUpdateKey)) || 0;
-    const latestChangeOrderTimestamp = (await Get(latestChangeOrderKey)) || 0;
-    const latestUpdateResultTimestamp = (await Get(latestUpdateResultKey)) || 0;
-    const latestCompletePlayersTimestamp =
-      (await Get(latestCompletePlayersKey)) || 0;
-    if (
-      cachedData &&
-      latestGameIdUpdateTimestamp < cachedData.timestamp &&
-      latestChangeOrderTimestamp < cachedData.timestamp &&
-      latestUpdateResultTimestamp < cachedData.timestamp &&
-      latestCompletePlayersTimestamp < cachedData.timestamp
-    ) {
-      console.log("using cache");
-      return res.json(cachedData.data);
-    }
-    console.log("get new data");
-    const data = await GetFromDB(req, res);
-    if (data.length !== 0) {
-      await Set(cacheKey, { data: data, timestamp: Date.now() });
-    }
+    const data = await GetVersionedCache(
+      cacheKey,
+      [
+        latestGameIdUpdateKey,
+        latestChangeOrderKey,
+        latestUpdateResultKey,
+        latestCompletePlayersKey,
+      ],
+      () => GetFromDB(req, res),
+      (loaded) => loaded.length !== 0,
+    );
     res.json(data);
   } catch (error) {
     console.log(error);

--- a/pages/api/current_schedule.js
+++ b/pages/api/current_schedule.js
@@ -1,5 +1,5 @@
 import GetClient from "../../lib/db_client";
-import { Get, Set } from "../../lib/redis_client";
+import { GetVersionedCache } from "../../lib/versioned_cache";
 
 async function GetFromDB(req, res) {
   const client = await GetClient();
@@ -17,22 +17,11 @@ const CurrentSchedule = async (req, res) => {
     const latest_game_id_update_key =
       "update_game_id_for_" + current_block_name;
     const cache_key = "current_schedule_for_" + block_name;
-    const latest_update_timestamp = (await Get(latest_update_id_key)) || 0;
-    const latest_game_id_update_timestamp =
-      (await Get(latest_game_id_update_key)) || 0;
-    const cached_data = await Get(cache_key);
-    if (
-      cached_data &&
-      latest_update_timestamp < cached_data.timestamp &&
-      latest_game_id_update_timestamp < cached_data.timestamp
-    ) {
-      console.log(`using cache for ${cache_key}`);
-      return res.json(cached_data.data);
-    }
-    console.log(`get new data for ${cache_key}`);
-    const data = await GetFromDB(req, res);
-    console.log(data);
-    await Set(cache_key, { data: data, timestamp: Date.now() });
+    const data = await GetVersionedCache(
+      cache_key,
+      [latest_update_id_key, latest_game_id_update_key],
+      () => GetFromDB(req, res),
+    );
     res.json(data);
   } catch (error) {
     console.log(error);

--- a/pages/api/edit_tournament/save.js
+++ b/pages/api/edit_tournament/save.js
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 import GetClient from "../../../lib/db_client";
-import { Set as RedisSet } from "../../../lib/redis_client";
+import { MarkResultUpdated } from "../../../lib/result_cache";
 
 const CSV_HEADER = [
   "id",
@@ -293,10 +293,7 @@ export default async function SaveTournament(req, res) {
 
     const timestamp = Date.now();
     await replaceEventTable(client, eventName, rows);
-    await RedisSet(
-      `latest_update_result_for_${eventName}_timestamp`,
-      timestamp,
-    );
+    await MarkResultUpdated(eventName);
     const csvResult = tryWriteCsv(originalDir, tournamentCsv, csv, timestamp);
 
     res.json({

--- a/pages/api/edit_tournament/save_block.js
+++ b/pages/api/edit_tournament/save_block.js
@@ -226,7 +226,7 @@ export default async function SaveBlock(req, res) {
 
     await replaceBlockTables(client, block, rows, gamesRows);
     await Promise.all([
-      TouchCacheVersion(`latest_update_block_${block}_timestamp`),
+      TouchCacheVersion(`latest_update_block_${block}_version`),
       TouchCacheVersion(`change_event_order_for_block_${block}`),
       TouchCacheVersion(`change_order_for_block_${block}`),
       TouchCacheVersion(`update_complete_players_for_block_${block}`),

--- a/pages/api/edit_tournament/save_block.js
+++ b/pages/api/edit_tournament/save_block.js
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 import GetClient from "../../../lib/db_client";
-import { Set as RedisSet } from "../../../lib/redis_client";
+import { TouchCacheVersion } from "../../../lib/versioned_cache";
 
 const BLOCK_HEADER = [
   "id",
@@ -225,12 +225,14 @@ export default async function SaveBlock(req, res) {
     const timestamp = Date.now();
 
     await replaceBlockTables(client, block, rows, gamesRows);
-    await RedisSet(`latest_update_block_${block}_timestamp`, timestamp);
-    await RedisSet(`change_event_order_for_block_${block}`, timestamp);
-    await RedisSet(`change_order_for_block_${block}`, timestamp);
-    await RedisSet(`update_complete_players_for_block_${block}`, timestamp);
-    await RedisSet(`update_id_for_current_block_${block}`, timestamp);
-    await RedisSet(`update_game_id_for_current_block_${block}`, timestamp);
+    await Promise.all([
+      TouchCacheVersion(`latest_update_block_${block}_timestamp`),
+      TouchCacheVersion(`change_event_order_for_block_${block}`),
+      TouchCacheVersion(`change_order_for_block_${block}`),
+      TouchCacheVersion(`update_complete_players_for_block_${block}`),
+      TouchCacheVersion(`update_id_for_current_block_${block}`),
+      TouchCacheVersion(`update_game_id_for_current_block_${block}`),
+    ]);
 
     const originalDir = path.join(
       process.cwd(),

--- a/pages/api/edit_tournament/save_block.js
+++ b/pages/api/edit_tournament/save_block.js
@@ -226,7 +226,6 @@ export default async function SaveBlock(req, res) {
 
     await replaceBlockTables(client, block, rows, gamesRows);
     await Promise.all([
-      TouchCacheVersion(`latest_update_block_${block}_version`),
       TouchCacheVersion(`change_event_order_for_block_${block}`),
       TouchCacheVersion(`change_order_for_block_${block}`),
       TouchCacheVersion(`update_complete_players_for_block_${block}`),

--- a/pages/api/edit_tournament/save_table_order.js
+++ b/pages/api/edit_tournament/save_table_order.js
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 import GetClient from "../../../lib/db_client";
-import { Set as RedisSet } from "../../../lib/redis_client";
+import { MarkResultUpdated } from "../../../lib/result_cache";
 
 const DANTAI_HOKEI_HEADER = [
   "id",
@@ -199,10 +199,7 @@ export default async function SaveTableOrder(req, res) {
     const timestamp = Date.now();
 
     await replaceEventTable(client, eventName, rows);
-    await RedisSet(
-      `latest_update_result_for_${eventName}_timestamp`,
-      timestamp,
-    );
+    await MarkResultUpdated(eventName);
 
     const originalDir = path.join(
       process.cwd(),

--- a/pages/api/get_game_ids_on_block.ts
+++ b/pages/api/get_game_ids_on_block.ts
@@ -1,7 +1,7 @@
 // あるブロックの、試合のリストを返す
 import { NextApiRequest, NextApiResponse } from "next";
 import GetClient from "../../lib/db_client";
-import { Get, Set } from "../../lib/redis_client";
+import { GetVersionedCache } from "../../lib/versioned_cache";
 
 export interface GameIdsData {
   id: number;
@@ -34,23 +34,13 @@ const GetGameIdsOnBlock = async (
   try {
     const block_name = "block_" + req.query.block_number;
     const cache_key = "get_game_ids_on_" + block_name;
-    const cached_data = await Get(cache_key);
     const change_event_order_cache_key = "change_event_order_for_" + block_name;
-    const latest_change_event_order_timestamp =
-      (await Get(change_event_order_cache_key)) || 0;
-
-    if (
-      cached_data &&
-      latest_change_event_order_timestamp < cached_data.timestamp
-    ) {
-      console.log(`using cache for ${cache_key}`);
-      return res.json(cached_data.data);
-    }
-    console.log(`get new data for ${cache_key}`);
-    const data = await GetFromDB(req);
-    if (data) {
-      await Set(cache_key, { data: data, timestamp: Date.now() });
-    }
+    const data = await GetVersionedCache(
+      cache_key,
+      [change_event_order_cache_key],
+      () => GetFromDB(req),
+      Boolean,
+    );
     res.json(data);
   } catch (error) {
     console.log(error);

--- a/pages/api/get_games_on_block.js
+++ b/pages/api/get_games_on_block.js
@@ -1,5 +1,5 @@
 import GetClient from "../../lib/db_client";
-import { Get, Set } from "../../lib/redis_client";
+import { GetVersionedCache } from "../../lib/versioned_cache";
 
 function update(sorted_data, item, block_indices, value, round) {
   if ("prev_left_id" in item) {
@@ -331,8 +331,6 @@ const GetGamesOnBlock = async (req, res) => {
       event_name +
       "_" +
       (req.query.schedule_id || "current");
-    const cachedData = await Get(cacheKey);
-
     const latestIdUpdateKey = "update_id_for_" + current_block_name;
     const latestGameIdUpdateKey = "update_game_id_for_" + current_block_name;
     const latestChangeOrderKey = "change_order_for_" + block_name;
@@ -341,28 +339,18 @@ const GetGamesOnBlock = async (req, res) => {
     const latestCompletePlayersKey =
       "update_complete_players_for_" + block_name;
 
-    const latestIdUpdateTimestamp = (await Get(latestIdUpdateKey)) || 0;
-    const latestGameIdUpdateTimestamp = (await Get(latestGameIdUpdateKey)) || 0;
-    const latestChangeOrderTimestamp = (await Get(latestChangeOrderKey)) || 0;
-    const latestUpdateResultTimestamp = (await Get(latestUpdateResultKey)) || 0;
-    const latestCompletePlayersTimestamp =
-      (await Get(latestCompletePlayersKey)) || 0;
-    if (
-      cachedData &&
-      latestIdUpdateTimestamp < cachedData.timestamp &&
-      latestGameIdUpdateTimestamp < cachedData.timestamp &&
-      latestChangeOrderTimestamp < cachedData.timestamp &&
-      latestUpdateResultTimestamp < cachedData.timestamp &&
-      latestCompletePlayersTimestamp < cachedData.timestamp
-    ) {
-      console.log("using cache");
-      return res.json(cachedData.data);
-    }
-    console.log("get new data");
-    const data = await GetFromDB(req, res, event_name);
-    if (data.length !== 0) {
-      await Set(cacheKey, { data: data, timestamp: Date.now() });
-    }
+    const data = await GetVersionedCache(
+      cacheKey,
+      [
+        latestIdUpdateKey,
+        latestGameIdUpdateKey,
+        latestChangeOrderKey,
+        latestUpdateResultKey,
+        latestCompletePlayersKey,
+      ],
+      () => GetFromDB(req, res, event_name),
+      (loaded) => loaded.length !== 0,
+    );
     res.json(data);
   } catch (error) {
     console.log(error);

--- a/pages/api/get_games_on_block.js
+++ b/pages/api/get_games_on_block.js
@@ -335,7 +335,7 @@ const GetGamesOnBlock = async (req, res) => {
     const latestGameIdUpdateKey = "update_game_id_for_" + current_block_name;
     const latestChangeOrderKey = "change_order_for_" + block_name;
     const latestUpdateResultKey =
-      "latest_update_result_for_" + event_name + "_timestamp";
+      "latest_update_result_for_" + event_name + "_version";
     const latestCompletePlayersKey =
       "update_complete_players_for_" + block_name;
 

--- a/pages/api/get_result.js
+++ b/pages/api/get_result.js
@@ -1,6 +1,7 @@
 import GetClient from "../../lib/db_client";
 import { Get, Set } from "../../lib/redis_client";
 import { applyTournamentLayout } from "../../lib/tournament_layout";
+import { GetResultWithCache } from "../../lib/result_cache";
 
 async function GetFromDB(req, res) {
   const client = await GetClient();
@@ -63,23 +64,13 @@ const GetResult = async (req, res) => {
         return res.json(freezedData.data);
       } else {
         const data = await GetFromDB(req, res);
-        await Set(freezedKey, { data: data, timestamp: Date.now() });
+        await Set(freezedKey, { data });
         return res.json(data);
       }
     }
-    const latestUpdateKey =
-      "latest_update_result_for_" + event_name + "_timestamp";
-    const cacheKey = "get_result_for_" + event_name + "_cache_data";
-    const cachedData = await Get(cacheKey);
-    const latestUpdateTimestamp = (await Get(latestUpdateKey)) || 0;
-    if (cachedData && latestUpdateTimestamp < cachedData.timestamp) {
-      console.log("using cache");
-      return res.json(cachedData.data);
-    }
-    console.log("get new data");
-    const data = await GetFromDB(req, res);
-    console.log(data);
-    await Set(cacheKey, { data: data, timestamp: Date.now() });
+    const data = await GetResultWithCache(event_name, () =>
+      GetFromDB(req, res),
+    );
     res.json(data);
   } catch (error) {
     console.log(error);

--- a/pages/api/get_table_progress_on_block.js
+++ b/pages/api/get_table_progress_on_block.js
@@ -1,6 +1,6 @@
 import GetClient from "../../lib/db_client";
-import { Get, Set } from "../../lib/redis_client";
 import { GetEventName } from "../../lib/get_event_name";
+import { GetVersionedCache } from "../../lib/versioned_cache";
 
 async function GetFromDB(req, res, event_name) {
   const client = await GetClient();
@@ -69,8 +69,6 @@ const GetTableProgressOnBlock = async (req, res) => {
       event_name +
       "_" +
       (req.query.schedule_id || "current");
-    const cachedData = await Get(cacheKey);
-
     const latestIdUpdateKey = "update_id_for_" + current_block_name;
     const latestGameIdUpdateKey = "update_game_id_for_" + current_block_name;
     const latestChangeOrderKey = "change_order_for_" + block_name;
@@ -79,28 +77,18 @@ const GetTableProgressOnBlock = async (req, res) => {
     const latestCompletePlayersKey =
       "update_complete_players_for_" + block_name;
 
-    const latestIdUpdateTimestamp = (await Get(latestIdUpdateKey)) || 0;
-    const latestGameIdUpdateTimestamp = (await Get(latestGameIdUpdateKey)) || 0;
-    const latestChangeOrderTimestamp = (await Get(latestChangeOrderKey)) || 0;
-    const latestUpdateResultTimestamp = (await Get(latestUpdateResultKey)) || 0;
-    const latestCompletePlayersTimestamp =
-      (await Get(latestCompletePlayersKey)) || 0;
-    if (
-      cachedData &&
-      latestIdUpdateTimestamp < cachedData.timestamp &&
-      latestGameIdUpdateTimestamp < cachedData.timestamp &&
-      latestChangeOrderTimestamp < cachedData.timestamp &&
-      latestUpdateResultTimestamp < cachedData.timestamp &&
-      latestCompletePlayersTimestamp < cachedData.timestamp
-    ) {
-      console.log("using cache");
-      return res.json(cachedData.data);
-    }
-    console.log("get new data");
-    const data = await GetFromDB(req, res, event_name);
-    if (data.length !== 0) {
-      await Set(cacheKey, { data: data, timestamp: Date.now() });
-    }
+    const data = await GetVersionedCache(
+      cacheKey,
+      [
+        latestIdUpdateKey,
+        latestGameIdUpdateKey,
+        latestChangeOrderKey,
+        latestUpdateResultKey,
+        latestCompletePlayersKey,
+      ],
+      () => GetFromDB(req, res, event_name),
+      (loaded) => loaded.length !== 0,
+    );
     res.json(data);
   } catch (error) {
     console.log(error);

--- a/pages/api/get_table_progress_on_block.js
+++ b/pages/api/get_table_progress_on_block.js
@@ -73,7 +73,7 @@ const GetTableProgressOnBlock = async (req, res) => {
     const latestGameIdUpdateKey = "update_game_id_for_" + current_block_name;
     const latestChangeOrderKey = "change_order_for_" + block_name;
     const latestUpdateResultKey =
-      "latest_update_result_for_" + event_name + "_timestamp";
+      "latest_update_result_for_" + event_name + "_version";
     const latestCompletePlayersKey =
       "update_complete_players_for_" + block_name;
 

--- a/pages/api/get_table_result.js
+++ b/pages/api/get_table_result.js
@@ -1,21 +1,12 @@
-import { Get, Set } from "../../lib/redis_client";
 import { GetTableResult } from "../../lib/get_table_result";
+import { GetResultWithCache } from "../../lib/result_cache";
 
 const GetResult = async (req, res) => {
   try {
     const event_name = req.query.event_name;
-    const latest_update_key =
-      "latest_update_result_for_" + event_name + "_timestamp";
-    const cache_key = "get_result_for_" + event_name + "_cache_data";
-    const cached_data = await Get(cache_key);
-    const latest_update_timestamp = (await Get(latest_update_key)) || 0;
-    if (cached_data && latest_update_timestamp < cached_data.timestamp) {
-      console.log("using cache");
-      return res.json(cached_data.data);
-    }
-    console.log("get new data");
-    const data = await GetTableResult(req.query.event_name);
-    await Set(cache_key, { data: data, timestamp: Date.now() });
+    const data = await GetResultWithCache(event_name, () =>
+      GetTableResult(event_name),
+    );
     res.json(data);
   } catch (error) {
     console.log(error);

--- a/pages/api/get_time_schedule.js
+++ b/pages/api/get_time_schedule.js
@@ -1,5 +1,5 @@
 import GetClient from "../../lib/db_client";
-import { Get, Set } from "../../lib/redis_client";
+import { GetVersionedCache } from "../../lib/versioned_cache";
 
 async function GetFromDB(req, res) {
   const client = await GetClient();
@@ -69,22 +69,11 @@ const GetTimeSchedule = async (req, res) => {
     const latest_change_event_order_key =
       "change_event_order_for_" + block_name;
     const cache_key = "time_schedule_for_" + block_name;
-    const latest_update_timestamp = (await Get(latest_update_key)) || 0;
-    const latest_change_event_order_timestamp =
-      (await Get(latest_change_event_order_key)) || 0;
-    const cached_data = await Get(cache_key);
-    if (
-      cached_data &&
-      latest_update_timestamp < cached_data.timestamp &&
-      latest_change_event_order_timestamp < cached_data.timestamp
-    ) {
-      console.log(`using cache for ${cache_key}`);
-      return res.json(cached_data.data);
-    }
-    console.log(`get new data for ${cache_key}`);
-    const data = await GetFromDB(req, res);
-    console.log(data);
-    await Set(cache_key, { data: data, timestamp: Date.now() });
+    const data = await GetVersionedCache(
+      cache_key,
+      [latest_update_key, latest_change_event_order_key],
+      () => GetFromDB(req, res),
+    );
     res.json(data);
   } catch (error) {
     console.log(error);

--- a/pages/api/notification_request.js
+++ b/pages/api/notification_request.js
@@ -1,5 +1,5 @@
 import GetClient from "../../lib/db_client";
-import { Get, Set } from "../../lib/redis_client";
+import { GetVersionedCache } from "../../lib/versioned_cache";
 
 async function GetFromDB(req, res, notification_request_name) {
   const client = await GetClient();
@@ -48,21 +48,13 @@ const NotificationRequest = async (req, res) => {
       ? "test_notification_request"
       : "notification_request";
     const cacheKey = "get_" + notification_request_name;
-    const cachedData = await Get(cacheKey);
     const latestNotificationUpdateKey =
       "latest_update_for_" + notification_request_name;
-    const latestNotificationUpdateTimestamp =
-      (await Get(latestNotificationUpdateKey)) || 0;
-    if (
-      cachedData &&
-      latestNotificationUpdateTimestamp < cachedData.timestamp
-    ) {
-      console.log("using cache");
-      return res.json(cachedData.data);
-    }
-    console.log("get new data");
-    const data = await GetFromDB(req, res, notification_request_name);
-    await Set(cacheKey, { data: data, timestamp: Date.now() });
+    const data = await GetVersionedCache(
+      cacheKey,
+      [latestNotificationUpdateKey],
+      () => GetFromDB(req, res, notification_request_name),
+    );
     res.json(data);
   } catch (error) {
     console.log(error);

--- a/pages/api/record.js
+++ b/pages/api/record.js
@@ -1,15 +1,21 @@
 import GetClient from "../../lib/db_client";
-import { Set } from "../../lib/redis_client";
+import { MarkResultUpdated } from "../../lib/result_cache";
+import { TouchCacheVersion } from "../../lib/versioned_cache";
 
 const Record = async (req, res) => {
   try {
     const client = await GetClient();
     const event_name = req.body.event_name;
+    const game_id = Number(req.body.id);
+    if (!Number.isInteger(game_id) || game_id < 1) {
+      res.status(400).json({ error: "Invalid game ID" });
+      return;
+    }
     const type = event_name.includes("dantai") ? "group" : "player";
     let query =
       "update " + event_name + " set left_" + type + "_flag = $2 where id = $1";
     let values = [
-      req.body.id,
+      game_id,
       type === "group" ? req.body.left_group_flag : req.body.left_player_flag,
     ];
     let result = await client.query(query, values);
@@ -45,9 +51,7 @@ const Record = async (req, res) => {
         result = await client.query(query, values);
       }
     }
-    const key = "latest_update_result_for_" + event_name + "_timestamp";
-    const timestamp = Date.now();
-    await Set(key, timestamp);
+    await MarkResultUpdated(event_name);
     if (req.body.update_block === undefined || req.body.update_block === null) {
       res.json({});
       return;
@@ -67,12 +71,12 @@ const Record = async (req, res) => {
     result = await client.query(query);
     console.log(result.rows);
     const update_game_id_key = "update_game_id_for_" + current_block_name;
-    await Set(update_game_id_key, timestamp);
+    await TouchCacheVersion(update_game_id_key);
     if (result.rows.length === 0) {
       query = "update " + current_block_name + " set id = id + 1, game_id = 1";
       result = await client.query(query);
       const update_id_key = "update_id_for_" + current_block_name;
-      await Set(update_id_key, timestamp);
+      await TouchCacheVersion(update_id_key);
     } else {
       query = "update " + current_block_name + " set game_id = " + next_game_id;
       result = await client.query(query);

--- a/pages/api/record_table.js
+++ b/pages/api/record_table.js
@@ -1,10 +1,16 @@
 import GetClient from "../../lib/db_client";
-import { Set } from "../../lib/redis_client";
+import { MarkResultUpdated } from "../../lib/result_cache";
+import { TouchCacheVersion } from "../../lib/versioned_cache";
 
 const RecordTable = async (req, res) => {
   try {
     const client = await GetClient();
     const event_name = req.body.event_name;
+    const game_id = Number(req.body.id);
+    if (!Number.isInteger(game_id) || game_id < 1) {
+      res.status(400).json({ error: "Invalid game ID" });
+      return;
+    }
     let query = "update " + event_name + " set ";
     let initial_value_is_set = false;
     if (req.body.main_score || req.body.retire) {
@@ -90,10 +96,8 @@ const RecordTable = async (req, res) => {
       initial_value_is_set = true;
     }
     query += " where id = $1";
-    let result = await client.query(query, [req.body.id]);
-    const key = "latest_update_result_for_" + event_name + "_timestamp";
-    const timestamp = Date.now();
-    await Set(key, timestamp);
+    let result = await client.query(query, [game_id]);
+    await MarkResultUpdated(event_name);
     // update current block if necessary
     if (req.body.update_block === undefined || req.body.update_block === null) {
       res.json({});
@@ -114,12 +118,12 @@ const RecordTable = async (req, res) => {
     result = await client.query(query);
     console.log(result.rows);
     const update_game_id_key = "update_game_id_for_" + current_block_name;
-    await Set(update_game_id_key, timestamp);
+    await TouchCacheVersion(update_game_id_key);
     if (result.rows.length === 0) {
       query = "update " + current_block_name + " set id = id + 1, game_id = 1";
       result = await client.query(query);
       const update_id_key = "update_id_for_" + current_block_name;
-      await Set(update_id_key, timestamp);
+      await TouchCacheVersion(update_id_key);
     } else {
       query = "update " + current_block_name + " set game_id = " + next_game_id;
       result = await client.query(query);

--- a/pages/api/reset_db.js
+++ b/pages/api/reset_db.js
@@ -1,5 +1,6 @@
 import GetClient from "../../lib/db_client";
-import { Get, Set } from "../../lib/redis_client";
+import { MarkResultUpdated } from "../../lib/result_cache";
+import { TouchCacheVersion } from "../../lib/versioned_cache";
 import fs from "fs";
 //import { parse } from 'csv-parse';
 import path from "path";
@@ -150,24 +151,20 @@ const ResetDb = async (req, res) => {
     let query;
     query = "DELETE FROM " + (is_test ? "test_" : "") + "notification_request";
     await client.query(query);
-    // update timestamp to current
-    const timestamp = Date.now();
     for (let i = 0; i < req.body.event_names.length; i++) {
       const event_name = req.body.event_names[i];
-      await Set(
-        "latest_update_result_for_" + event_name + "_timestamp",
-        timestamp,
-      );
+      await MarkResultUpdated(event_name);
     }
     for (let i = 0; i < req.body.block_names.length; i++) {
       const block_name = req.body.block_names[i];
-      await Set("update_id_for_current_" + block_name, timestamp);
-      await Set("update_game_id_for_current_" + block_name, timestamp);
-      await Set("update_complete_players_for_" + block_name, timestamp);
+      await Promise.all([
+        TouchCacheVersion("update_id_for_current_" + block_name),
+        TouchCacheVersion("update_game_id_for_current_" + block_name),
+        TouchCacheVersion("update_complete_players_for_" + block_name),
+      ]);
     }
-    await Set(
+    await TouchCacheVersion(
       "latest_update_for_" + (is_test ? "test_" : "") + "notification_request",
-      timestamp,
     );
     res.json([]);
   } catch (error) {

--- a/pages/api/reset_result.js
+++ b/pages/api/reset_result.js
@@ -1,5 +1,5 @@
 import GetClient from "../../lib/db_client";
-import { Set } from "../../lib/redis_client";
+import { MarkResultUpdated } from "../../lib/result_cache";
 
 const ResetResult = async (req, res) => {
   let client;
@@ -73,9 +73,8 @@ const ResetResult = async (req, res) => {
       }
     }
 
-    const key = "latest_update_result_for_" + eventName + "_timestamp";
-    await Set(key, Date.now());
     await client.query("COMMIT");
+    await MarkResultUpdated(eventName);
     res.json({});
   } catch (error) {
     if (client) {

--- a/pages/api/update_current_schedule.js
+++ b/pages/api/update_current_schedule.js
@@ -1,5 +1,5 @@
 import GetClient from "../../lib/db_client";
-import { Set } from "../../lib/redis_client";
+import { TouchCacheVersion } from "../../lib/versioned_cache";
 
 const UpdateCurrentSchedule = async (req, res) => {
   try {
@@ -9,9 +9,8 @@ const UpdateCurrentSchedule = async (req, res) => {
     const query = "update " + current_block_name + " set id = $1, game_id = 1";
     const values = [schedule_id];
     const result = await client.query(query, values);
-    const timestamp = Date.now();
     const update_id_key = "update_id_for_" + current_block_name;
-    await Set(update_id_key, timestamp);
+    await TouchCacheVersion(update_id_key);
     res.json({});
   } catch (error) {
     console.log(error);


### PR DESCRIPTION
redisキャッシュをtimestampの代わりにINCRによるバージョン更新を用いた方法に変更することによって、
キャッシュアクセスの削減と、同時更新時のキャッシュ不整合の修正を行います