### PR TITLE
fix empty player id is not editable

### DIFF
--- a/ci/cloudbuild_template.yaml
+++ b/ci/cloudbuild_template.yaml
@@ -88,7 +88,7 @@ steps:
           --no-cpu-throttling \
           --max-instances 1 \
           --min-instances 0 \
-          --add-cloudsql-instances $$PROJECT_ID:asia-northeast1:$$CLOUDSQL_INSTANCE_ID \
+          --set-cloudsql-instances $$PROJECT_ID:asia-northeast1:$$CLOUDSQL_INSTANCE_ID \
           --update-env-vars COMPETITION_NAME=$$COMPETITION_NAME \
           --update-env-vars PGSQL_DATABASE=postgres \
           --update-env-vars PGSQL_HOST=/cloudsql/$$PROJECT_ID:asia-northeast1:$$CLOUDSQL_INSTANCE_ID \

--- a/components/tournament_editor.js
+++ b/components/tournament_editor.js
@@ -285,7 +285,7 @@ function PlayerText({
         onClick={() => onSelectSlot(item.original_id, side)}
         onTap={() => onSelectSlot(item.original_id, side)}
       />
-      {showPlayerIds && playerId ? (
+      {showPlayerIds ? (
         <>
           <Rect
             x={playerIdX - 2}
@@ -303,7 +303,7 @@ function PlayerText({
           <Text
             x={playerIdX}
             y={textY - 9}
-            text={playerId}
+            text={playerId || ""}
             width={24}
             align="center"
             fill="#4b5b68"


### PR DESCRIPTION
トーナメント編集画面で、選手IDを空にすると編集できなくなるバグがあったので修正します