### PR TITLE
use cache for current match overlay

### DIFF
--- a/lib/current_match_overlay.js
+++ b/lib/current_match_overlay.js
@@ -1,6 +1,8 @@
 import GetClient from "./db_client";
+import { GetVersionedCache } from "./versioned_cache";
 
 const COURT_PATTERN = /^[a-z]$/;
+const pendingLoads = new Map();
 
 export function NormalizeCourt(value) {
   const court = Array.isArray(value) ? value[0] : value;
@@ -25,7 +27,7 @@ function BuildDisplayText(competitionName, matchNumber, participantNames) {
   return parts.filter(Boolean).join("｜");
 }
 
-export async function GetCurrentMatchForCourt(court) {
+async function LoadCurrentMatchForCourt(court) {
   const client = await GetClient();
   const courtId = court.charCodeAt(0) - 96;
   const courtResult = await client.query(
@@ -145,4 +147,34 @@ export async function GetCurrentMatchForCourt(court) {
       participantNames,
     ),
   };
+}
+
+export async function GetCurrentMatchForCourt(court) {
+  const cacheKey = `current_match_overlay_for_${court}`;
+  const currentBlockName = `current_block_${court}`;
+  const versionKeys = [
+    `update_id_for_${currentBlockName}`,
+    `update_game_id_for_${currentBlockName}`,
+    `change_event_order_for_block_${court}`,
+    `change_order_for_block_${court}`,
+  ];
+
+  // Share one cache check/database load within this server process when many
+  // viewers request the same court at once.
+  if (pendingLoads.has(cacheKey)) {
+    return pendingLoads.get(cacheKey);
+  }
+
+  const load = GetVersionedCache(cacheKey, versionKeys, () =>
+    LoadCurrentMatchForCourt(court),
+  );
+  pendingLoads.set(cacheKey, load);
+
+  try {
+    return await load;
+  } finally {
+    if (pendingLoads.get(cacheKey) === load) {
+      pendingLoads.delete(cacheKey);
+    }
+  }
 }


### PR DESCRIPTION
ライブ配信用に新規追加したAPIが全部DBアクセスになってしまったため、他と同様キャッシュを使えるようにします