### PR TITLE
reduce redundant api access

### DIFF
--- a/components/get_result.js
+++ b/components/get_result.js
@@ -1183,19 +1183,30 @@ function GetResult({
   const [blinkState, setBlinkState] = useState(true);
 
   const fetchCurrentBlock = useCallback(async () => {
-    const blockData = {};
-    for (const court of courts) {
-      const blockNumber = court.name.replace(/['"コート]/g, "").toLowerCase();
-      try {
-        const result = await FetchJson(
-          `/api/current_block?block_number=${blockNumber}&event_name=${event_name}`,
-        );
-        blockData[blockNumber] = result;
-      } catch (error) {
-        console.error(`Failed to update current block ${blockNumber}`, error);
-      }
+    const blockNumbers = courts.map((court) =>
+      court.name.replace(/['"コート]/g, "").toLowerCase(),
+    );
+    if (blockNumbers.length === 0) {
+      return;
     }
-    setCurrentBlockData((previous) => ({ ...previous, ...blockData }));
+    try {
+      const blockData = await FetchJson(
+        "/api/current_games_for_courts?type=tournament&event_name=" +
+          encodeURIComponent(event_name) +
+          "&block_numbers=" +
+          encodeURIComponent(blockNumbers.join(",")),
+      );
+      if (
+        !blockData ||
+        typeof blockData !== "object" ||
+        Array.isArray(blockData)
+      ) {
+        throw new Error("Invalid current blocks response");
+      }
+      setCurrentBlockData((previous) => ({ ...previous, ...blockData }));
+    } catch (error) {
+      console.error("Failed to update current blocks", error);
+    }
   }, [courts, event_name]);
 
   useEffect(() => {
@@ -1262,7 +1273,9 @@ function GetResult({
       }
     }
     if (!hide && show_highlight) {
-      fetchCourts();
+      if (courts.length === 0) {
+        fetchCourts();
+      }
       fetchCurrentBlock();
     }
     if (updateInterval > 0) {
@@ -1277,12 +1290,6 @@ function GetResult({
       };
     }
   }, [event_name, updateInterval, block_number, courts.length]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  useEffect(() => {
-    if (courts.length > 0) {
-      fetchCurrentBlock();
-    }
-  }, [courts.length]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (Object.keys(currentBlockData).length > 0) {

--- a/components/get_table_result.tsx
+++ b/components/get_table_result.tsx
@@ -365,42 +365,45 @@ const GetTableResult: React.FC<{
   );
 
   const fetchCurrentGames = useCallback(async () => {
-    const entries = await Promise.all(
-      courts.map(async (court) => {
-        const blockNumber = String(court.name || "")
+    const blockNumbers = courts
+      .map((court) =>
+        String(court.name || "")
           .replace(/['"コート]/g, "")
-          .toLowerCase();
-        if (!blockNumber) {
-          return null;
+          .toLowerCase(),
+      )
+      .filter(Boolean);
+    try {
+      const games = await FetchJson(
+        "/api/current_games_for_courts?type=table&event_name=" +
+          encodeURIComponent(event_name) +
+          "&block_numbers=" +
+          encodeURIComponent(blockNumbers.join(",")),
+      );
+      if (!games || typeof games !== "object" || Array.isArray(games)) {
+        throw new Error("Invalid current table games response");
+      }
+      const currentGames = { ...currentGamesRef.current };
+      blockNumbers.forEach((blockNumber) => {
+        if (!(blockNumber in games)) {
+          return;
         }
-        try {
-          const response = await fetch(
-            "/api/current_game_on_table?block_number=" +
-              encodeURIComponent(blockNumber) +
-              "&event_name=" +
-              encodeURIComponent(event_name),
-          );
-          if (!response.ok) {
-            return null;
-          }
-          const game = await response.json();
-          return game?.id ? [blockNumber, game] : null;
-        } catch (error) {
-          console.error("Failed to fetch current table game", error);
-          return null;
+        if (games[blockNumber]?.id) {
+          currentGames[blockNumber] = games[blockNumber];
+        } else {
+          delete currentGames[blockNumber];
         }
-      }),
-    );
-    const currentGames = Object.fromEntries(entries.filter(Boolean));
-    currentGamesRef.current = currentGames;
-    await fetchData(currentGames);
+      });
+      currentGamesRef.current = currentGames;
+      await fetchData(currentGames);
+    } catch (error) {
+      console.error("Failed to fetch current table games", error);
+    }
   }, [courts, event_name, fetchData]);
 
   useEffect(() => {
     currentGamesRef.current = {};
     setCourts([]);
     if (hide || !show_highlight) {
-      fetchData({});
       return;
     }
     const query = event_name.includes("test") ? "?is_test=true" : "";
@@ -426,16 +429,19 @@ const GetTableResult: React.FC<{
   }, [courts.length, fetchCurrentGames, hide, show_highlight, update_interval]);
 
   useEffect(() => {
+    // Once courts are available, fetchCurrentGames also refreshes the result.
+    // Keep this fallback for pages without highlighting and while courts load.
+    if (!hide && show_highlight && courts.length > 0) {
+      return;
+    }
     fetchData();
     if (update_interval > 0) {
-      const interval = setInterval(() => {
-        fetchData();
-      }, update_interval);
+      const interval = setInterval(fetchData, update_interval);
       return () => {
         clearInterval(interval);
       };
     }
-  }, [fetchData, update_interval]);
+  }, [courts.length, fetchData, hide, show_highlight, update_interval]);
 
   const fetchEventInfo = useCallback(async () => {
     try {

--- a/pages/api/current_block.js
+++ b/pages/api/current_block.js
@@ -1,5 +1,4 @@
 import GetClient from "../../lib/db_client";
-import { GetEventName } from "../../lib/get_event_name";
 import { GetVersionedCache } from "../../lib/versioned_cache";
 
 function update(sorted_data, item, block_indices, value, round) {
@@ -32,7 +31,7 @@ function update(sorted_data, item, block_indices, value, round) {
   item["block_pos"] = value;
 }
 
-async function GetFromDB(req, res) {
+async function GetFromDB(req) {
   const client = await GetClient();
   const block_name = "block_" + req.query.block_number;
   const current_block_name = "current_" + block_name;
@@ -245,33 +244,36 @@ async function GetFromDB(req, res) {
   return [];
 }
 
+export async function GetCurrentBlockData(query) {
+  const block_name = "block_" + query.block_number;
+  const current_block_name = "current_" + block_name;
+  const event_name = query.event_name;
+  const cacheKey =
+    "current_" + block_name + (event_name ? "_for_" + event_name : "");
+  const latestScheduleIdUpdateKey = "update_id_for_" + current_block_name;
+  const latestGameIdUpdateKey = "update_game_id_for_" + current_block_name;
+  const latestChangeOrderKey = "change_order_for_" + block_name;
+  const latestUpdateResultKey =
+    "latest_update_result_for_" + event_name + "_version";
+  const latestCompletePlayersKey = "update_complete_players_for_" + block_name;
+
+  return GetVersionedCache(
+    cacheKey,
+    [
+      latestScheduleIdUpdateKey,
+      latestGameIdUpdateKey,
+      latestChangeOrderKey,
+      latestUpdateResultKey,
+      latestCompletePlayersKey,
+    ],
+    () => GetFromDB({ query }),
+    (loaded) => query.schedule_id === undefined || loaded.length !== 0,
+  );
+}
+
 const CurrentBlock = async (req, res) => {
   try {
-    const block_name = "block_" + req.query.block_number;
-    const current_block_name = "current_" + block_name;
-    const event_name = req.query.event_name;
-    const cacheKey =
-      "current_" + block_name + (event_name ? "_for_" + event_name : "");
-    const latestScheduleIdUpdateKey = "update_id_for_" + current_block_name;
-    const latestGameIdUpdateKey = "update_game_id_for_" + current_block_name;
-    const latestChangeOrderKey = "change_order_for_" + block_name;
-    const latestUpdateResultKey =
-      "latest_update_result_for_" + event_name + "_version";
-    const latestCompletePlayersKey =
-      "update_complete_players_for_" + block_name;
-
-    const data = await GetVersionedCache(
-      cacheKey,
-      [
-        latestScheduleIdUpdateKey,
-        latestGameIdUpdateKey,
-        latestChangeOrderKey,
-        latestUpdateResultKey,
-        latestCompletePlayersKey,
-      ],
-      () => GetFromDB(req, res),
-      (loaded) => req.query.schedule_id === undefined || loaded.length !== 0,
-    );
+    const data = await GetCurrentBlockData(req.query);
     res.json(data);
   } catch (error) {
     console.log(error);

--- a/pages/api/current_game_on_table.js
+++ b/pages/api/current_game_on_table.js
@@ -1,8 +1,7 @@
 import GetClient from "../../lib/db_client";
-import { GetEventName } from "../../lib/get_event_name";
 import { GetVersionedCache } from "../../lib/versioned_cache";
 
-async function GetFromDB(req, res) {
+async function GetFromDB(req) {
   const client = await GetClient();
   const block_name = "block_" + req.query.block_number;
   const current_block_name = "current_" + block_name;
@@ -65,33 +64,35 @@ async function GetFromDB(req, res) {
   return result_schedule.rows[0];
 }
 
+export async function GetCurrentGameOnTableData(query) {
+  const block_name = "block_" + query.block_number;
+  const current_block_name = "current_" + block_name;
+  const event_name = query.event_name;
+  const cacheKey = "current_game_on_table_" + block_name + "_for_" + event_name;
+  const latestScheduleIdUpdateKey = "update_id_for_" + current_block_name;
+  const latestGameIdUpdateKey = "update_game_id_for_" + current_block_name;
+  const latestChangeOrderKey = "change_order_for_" + block_name;
+  const latestUpdateResultKey =
+    "latest_update_result_for_" + event_name + "_version";
+  const latestCompletePlayersKey = "update_complete_players_for_" + block_name;
+
+  return GetVersionedCache(
+    cacheKey,
+    [
+      latestScheduleIdUpdateKey,
+      latestGameIdUpdateKey,
+      latestChangeOrderKey,
+      latestUpdateResultKey,
+      latestCompletePlayersKey,
+    ],
+    () => GetFromDB({ query }),
+    (loaded) => loaded.length !== 0,
+  );
+}
+
 const CurrentGameOnTable = async (req, res) => {
   try {
-    const block_name = "block_" + req.query.block_number;
-    const current_block_name = "current_" + block_name;
-    const event_name = req.query.event_name;
-    const cacheKey =
-      "current_game_on_table_" + block_name + "_for_" + event_name;
-    const latestScheduleIdUpdateKey = "update_id_for_" + current_block_name;
-    const latestGameIdUpdateKey = "update_game_id_for_" + current_block_name;
-    const latestChangeOrderKey = "change_order_for_" + block_name;
-    const latestUpdateResultKey =
-      "latest_update_result_for_" + event_name + "_version";
-    const latestCompletePlayersKey =
-      "update_complete_players_for_" + block_name;
-
-    const data = await GetVersionedCache(
-      cacheKey,
-      [
-        latestScheduleIdUpdateKey,
-        latestGameIdUpdateKey,
-        latestChangeOrderKey,
-        latestUpdateResultKey,
-        latestCompletePlayersKey,
-      ],
-      () => GetFromDB(req, res),
-      (loaded) => loaded.length !== 0,
-    );
+    const data = await GetCurrentGameOnTableData(req.query);
     res.json(data);
   } catch (error) {
     console.log(error);

--- a/pages/api/current_games_for_courts.js
+++ b/pages/api/current_games_for_courts.js
@@ -1,0 +1,54 @@
+import { GetCurrentBlockData } from "./current_block";
+import { GetCurrentGameOnTableData } from "./current_game_on_table";
+
+const EVENT_NAME_PATTERN = /^[a-z][a-z0-9_]*$/;
+const BLOCK_NUMBER_PATTERN = /^[a-z0-9_]+$/;
+const MAX_COURTS = 12;
+
+const CurrentGamesForCourts = async (req, res) => {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const { event_name, type } = req.query;
+  const blockNumbers = String(req.query.block_numbers || "")
+    .split(",")
+    .filter(Boolean);
+  if (
+    typeof event_name !== "string" ||
+    !EVENT_NAME_PATTERN.test(event_name) ||
+    !["table", "tournament"].includes(type) ||
+    blockNumbers.length === 0 ||
+    blockNumbers.length > MAX_COURTS ||
+    blockNumbers.some((blockNumber) => !BLOCK_NUMBER_PATTERN.test(blockNumber))
+  ) {
+    return res.status(400).json({ error: "Invalid query" });
+  }
+
+  const loadData =
+    type === "table" ? GetCurrentGameOnTableData : GetCurrentBlockData;
+  const settled = await Promise.allSettled(
+    blockNumbers.map(async (blockNumber) => [
+      blockNumber,
+      await loadData({ block_number: blockNumber, event_name }),
+    ]),
+  );
+  const data = Object.fromEntries(
+    settled
+      .filter((result) => result.status === "fulfilled")
+      .map((result) => result.value),
+  );
+  settled
+    .filter((result) => result.status === "rejected")
+    .forEach((result) =>
+      console.error("Failed to fetch current game", result.reason),
+    );
+
+  if (Object.keys(data).length === 0) {
+    return res.status(500).json({ error: "Error fetching data" });
+  }
+  return res.json(data);
+};
+
+export default CurrentGamesForCourts;


### PR DESCRIPTION
ハイライト表示時に重複しているAPIアクセスの削除や、各コート現在試合取得用に別途になっていたAPIアクセスをまとめるなど実施し、
サーバ負荷を減らします