### PR TITLE
protect danger APIs

### DIFF
--- a/doc/develop/utility.md
+++ b/doc/develop/utility.md
@@ -7,7 +7,6 @@
 (URL)/admin/danger_zone にアクセスし"データベース初期化"ボタンを押下することで、
 その名の通りデータベースを全て初期化できる。
 
-
 ## キャッシュリセット
 
 データベースを更新したものの、古いキャシュが参照されてしまってる場合は以下を実行、
@@ -51,6 +50,8 @@ curl "(URL)/api/record_awards?id=1&player_id=1"
 一般にデータベースを更新する方法が用意されている。
 
 例: block_aテーブルにおけるid=1のplayers_checked要素を1に更新
+
 ```bash
-curl "(URL)/api/update_db?id=1&table_name=block_a&key=players_checked&value=1"
+curl -u "$USERNAME:$PASSWORD" \
+  "(URL)/api/update_db?id=1&table_name=block_a&key=players_checked&value=1"
 ```

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 
 export const config = {
-  matcher: ["/admin/:path*", "/test/:path*"],
+  matcher: [
+    "/admin/:path*",
+    "/test/:path*",
+    "/api/edit_tournament/:path*",
+    "/api/reset_db",
+    "/api/update_db",
+  ],
 };
 
 export default function middleware(req: NextRequest) {


### PR DESCRIPTION
割と危険度の高いAPIをbasic認証の対象にしておきます
他のadmin操作系も全部塞いでもよいですが、一旦小規模で様子見