### PR TITLE
use SSE in get result component

### DIFF
--- a/components/get_result.js
+++ b/components/get_result.js
@@ -10,6 +10,7 @@ import { Layer, Stage, Rect, Text } from "react-konva";
 import Grid from "@mui/material/Grid";
 import Summary from "./show_summary";
 import { FetchJson } from "../lib/fetch_json";
+import { StartSseWithPolling } from "../lib/sse_with_polling";
 
 function CreateDantaiText(item, lineWidth, y_padding, hide = false) {
   const is_left = item["block_pos"] === "left";
@@ -1277,17 +1278,34 @@ function GetResult({
       }
       fetchCurrentBlock();
     }
-    if (updateInterval > 0) {
-      const interval = setInterval(() => {
+
+    const refreshResultAndHighlight = () => {
+      fetchData();
+      if (!hide && show_highlight) {
+        fetchCurrentBlock();
+      }
+    };
+    const stopResultUpdates = StartSseWithPolling({
+      url: "/api/result_updates?event_name=" + encodeURIComponent(event_name),
+      eventName: "result-updated",
+      onUpdate: refreshResultAndHighlight,
+      pollInterval: updateInterval,
+    });
+
+    const fetchDataWhenVisible = () => {
+      if (document.visibilityState === "visible") {
         fetchData();
-        if (courts.length > 0) {
+        if (!hide && show_highlight) {
           fetchCurrentBlock();
         }
-      }, updateInterval);
-      return () => {
-        clearInterval(interval);
-      };
-    }
+      }
+    };
+    document.addEventListener("visibilitychange", fetchDataWhenVisible);
+
+    return () => {
+      stopResultUpdates();
+      document.removeEventListener("visibilitychange", fetchDataWhenVisible);
+    };
   }, [event_name, updateInterval, block_number, courts.length]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const { sortedData, maxHeight, numOfPlayers } = useMemo(() => {

--- a/lib/result_cache.js
+++ b/lib/result_cache.js
@@ -1,5 +1,6 @@
 import { GetVersionedCache, TouchCacheVersion } from "./versioned_cache";
 import { SingleFlight } from "./single_flight";
+import { PublishResultUpdate } from "./result_updates";
 
 function versionKey(eventName) {
   return `latest_update_result_for_${eventName}_version`;
@@ -11,6 +12,7 @@ function cacheKey(eventName) {
 
 export async function MarkResultUpdated(eventName) {
   await TouchCacheVersion(versionKey(eventName));
+  PublishResultUpdate(eventName);
 }
 
 export async function GetResultWithCache(eventName, loadData) {

--- a/lib/result_updates.js
+++ b/lib/result_updates.js
@@ -1,0 +1,22 @@
+const RESULT_UPDATES_KEY = Symbol.for(
+  "taido-competition-record.result-updates",
+);
+
+function GetListeners() {
+  if (!globalThis[RESULT_UPDATES_KEY]) {
+    globalThis[RESULT_UPDATES_KEY] = new Set();
+  }
+  return globalThis[RESULT_UPDATES_KEY];
+}
+
+export function PublishResultUpdate(eventName) {
+  for (const listener of GetListeners()) {
+    listener(eventName);
+  }
+}
+
+export function SubscribeResultUpdates(listener) {
+  const listeners = GetListeners();
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/lib/sse_with_polling.js
+++ b/lib/sse_with_polling.js
@@ -1,0 +1,91 @@
+const DEFAULT_CONNECTION_TIMEOUT_MS = 10000;
+const DEFAULT_HEARTBEAT_TIMEOUT_MS = 60000;
+const DEFAULT_WATCHDOG_INTERVAL_MS = 15000;
+
+export function StartSseWithPolling({
+  url,
+  eventName,
+  onUpdate,
+  pollInterval,
+  connectionTimeoutMs = DEFAULT_CONNECTION_TIMEOUT_MS,
+  heartbeatTimeoutMs = DEFAULT_HEARTBEAT_TIMEOUT_MS,
+  watchdogIntervalMs = DEFAULT_WATCHDOG_INTERVAL_MS,
+}) {
+  let eventSource = null;
+  let fallbackInterval = null;
+  let connectionTimeout = null;
+  let heartbeatWatchdog = null;
+  let sseHealthy = false;
+  let lastSseActivity = Date.now();
+
+  const stopFallbackPolling = () => {
+    if (fallbackInterval !== null) {
+      clearInterval(fallbackInterval);
+      fallbackInterval = null;
+    }
+  };
+  const startFallbackPolling = () => {
+    if (pollInterval <= 0 || fallbackInterval !== null) {
+      return;
+    }
+    onUpdate();
+    fallbackInterval = setInterval(onUpdate, pollInterval);
+  };
+  const markSseHealthy = () => {
+    const recovered = !sseHealthy;
+    sseHealthy = true;
+    lastSseActivity = Date.now();
+    stopFallbackPolling();
+    return recovered;
+  };
+
+  if (typeof EventSource === "undefined") {
+    startFallbackPolling();
+  } else {
+    try {
+      eventSource = new EventSource(url);
+      eventSource.addEventListener(eventName, () => {
+        markSseHealthy();
+        onUpdate();
+      });
+      eventSource.addEventListener("heartbeat", () => {
+        if (markSseHealthy()) {
+          onUpdate();
+        }
+      });
+      eventSource.onopen = () => {
+        markSseHealthy();
+        onUpdate();
+      };
+      eventSource.onerror = () => {
+        sseHealthy = false;
+        startFallbackPolling();
+      };
+      connectionTimeout = setTimeout(() => {
+        if (!sseHealthy) {
+          startFallbackPolling();
+        }
+      }, connectionTimeoutMs);
+      heartbeatWatchdog = setInterval(() => {
+        if (Date.now() - lastSseActivity > heartbeatTimeoutMs) {
+          sseHealthy = false;
+          startFallbackPolling();
+        }
+      }, watchdogIntervalMs);
+    } catch (error) {
+      console.error("Failed to connect to result updates", error);
+      startFallbackPolling();
+    }
+  }
+
+  return () => {
+    stopFallbackPolling();
+    if (connectionTimeout !== null) {
+      clearTimeout(connectionTimeout);
+    }
+    if (heartbeatWatchdog !== null) {
+      clearInterval(heartbeatWatchdog);
+    }
+    eventSource?.close();
+  };
+}

--- a/pages/api/record.js
+++ b/pages/api/record.js
@@ -81,7 +81,7 @@ const Record = async (req, res) => {
     await client.query("COMMIT");
     transactionOpen = false;
 
-    const cacheUpdates = [MarkResultUpdated(event_name)];
+    const cacheUpdates = [];
     if (position) {
       const currentBlockName = `current_block_${block}`;
       cacheUpdates.push(
@@ -94,6 +94,7 @@ const Record = async (req, res) => {
       }
     }
     await Promise.all(cacheUpdates);
+    await MarkResultUpdated(event_name);
     res.json({});
   } catch (error) {
     if (transactionOpen && client) {

--- a/pages/api/record_table.js
+++ b/pages/api/record_table.js
@@ -127,7 +127,7 @@ const RecordTable = async (req, res) => {
     await client.query("COMMIT");
     transactionOpen = false;
 
-    const cacheUpdates = [MarkResultUpdated(event_name)];
+    const cacheUpdates = [];
     if (position) {
       const currentBlockName = `current_block_${block}`;
       cacheUpdates.push(
@@ -140,6 +140,7 @@ const RecordTable = async (req, res) => {
       }
     }
     await Promise.all(cacheUpdates);
+    await MarkResultUpdated(event_name);
     res.json({});
   } catch (error) {
     if (transactionOpen && client) {

--- a/pages/api/result_updates.js
+++ b/pages/api/result_updates.js
@@ -1,0 +1,50 @@
+import { SubscribeResultUpdates } from "../../lib/result_updates";
+
+const EVENT_NAME_PATTERN = /^[a-z][a-z0-9_]*$/;
+const HEARTBEAT_INTERVAL_MS = 25000;
+
+export const config = {
+  api: {
+    externalResolver: true,
+  },
+};
+
+export default function ResultUpdates(req, res) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+
+  const eventName = req.query.event_name;
+  if (typeof eventName !== "string" || !EVENT_NAME_PATTERN.test(eventName)) {
+    res.status(400).json({ error: "Invalid event name" });
+    return;
+  }
+
+  res.setHeader("Content-Type", "text/event-stream");
+  res.setHeader("Cache-Control", "no-cache, no-transform");
+  res.setHeader("Connection", "keep-alive");
+  res.setHeader("X-Accel-Buffering", "no");
+  res.flushHeaders?.();
+  res.socket?.setTimeout(0);
+  res.write("retry: 3000\n\n");
+
+  const unsubscribe = SubscribeResultUpdates((updatedEventName) => {
+    if (updatedEventName !== eventName) {
+      return;
+    }
+    res.write(
+      `event: result-updated\ndata: ${JSON.stringify({ eventName })}\n\n`,
+    );
+  });
+  const heartbeat = setInterval(() => {
+    res.write("event: heartbeat\ndata: {}\n\n");
+  }, HEARTBEAT_INTERVAL_MS);
+
+  req.on("close", () => {
+    clearInterval(heartbeat);
+    unsubscribe();
+    res.end();
+  });
+}


### PR DESCRIPTION
ポーリングではなく、SSE(Server-Sent Events)を利用し、サーバー側から更新通知を送る更新方法にします。

リアルタイム性があがりますが、セッションが維持されるようになります。
一旦get_result のみに適用

利用できない場合などはpolling方式に戻ります